### PR TITLE
README.md: fix typo in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,4 @@ The library is distributed using a modified BSD-style
 ## AVR LibC Source Code
 
 The official source code repository is located at
-https://gitlab.com/avrdudes/avr-libc/
-
-
+https://github.com/avrdudes/avr-libc/


### PR DESCRIPTION
As trivial as the title says. (At least there seems to be no such repo at Git***Lab*** and the NEWS says the new home Git***Hub***, so I assume this to be a typo.)