### PR TITLE
*.py: Use python3 instead of python

### DIFF
--- a/devtools/cr_check.py
+++ b/devtools/cr_check.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Copyright (c) 2004  Theodore A. Roth
 # All rights reserved.

--- a/devtools/gen-avr-lib-tree.sh
+++ b/devtools/gen-avr-lib-tree.sh
@@ -487,4 +487,7 @@ do
     done
 done
 
-./devtools/mlib-gen.py -devices tmp-device-info -cores tmp-core-info || exit 1
+# Allow users to overwrite the python version to use via environment variable
+# PYTHON
+export PYTHON=${PYTHON:-python3}
+${PYTHON} ./devtools/mlib-gen.py -devices tmp-device-info -cores tmp-core-info || exit 1

--- a/devtools/mlib-gen.py
+++ b/devtools/mlib-gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import os, sys

--- a/devtools/specs2libtree.py
+++ b/devtools/specs2libtree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # ----------------------------------------------------------------------------
 # "THE BEER-WARE LICENSE" (Revision 42):

--- a/tests/simulate/readcore.py
+++ b/tests/simulate/readcore.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # Copyright (c) 2008, Joerg Wunsch
 # All rights reserved.

--- a/xml/Atmel2libc.py
+++ b/xml/Atmel2libc.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Copyright (c) 2004,2005  Theodore A. Roth
 # All rights reserved.

--- a/xml/Descparser.py
+++ b/xml/Descparser.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Copyright (c) 2004  Theodore A. Roth
 # All rights reserved.

--- a/xml/Validate.py
+++ b/xml/Validate.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Copyright (c) 2004  Theodore A. Roth
 # All rights reserved.

--- a/xml/patch-headers.py
+++ b/xml/patch-headers.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Copyright (c) 2005,2006,2007  Joerg Wunsch
 # All rights reserved.


### PR DESCRIPTION
Many distros these days do not provide an unversioned python binary and scripts are more future proof if the explicitly specify the version of python they work with.