### PR TITLE
Fix inline asm constraints of wdt_enable, wdt_disable.

### DIFF
--- a/include/avr/wdt.h
+++ b/include/avr/wdt.h
@@ -232,7 +232,7 @@ __asm__ __volatile__ (  \
       [disable_mask]      "r" ((uint8_t)((~WDT_ENABLE_bm) | WDT_CEN_bm)) \
     : "r0" \
 ); \
-while(0)
+} while(0)
 
 #endif // defined (WDT_CTRLA) && !defined(RAMPD)
 
@@ -255,7 +255,7 @@ __asm__ __volatile__ ( \
       | _BV(WDE) | (value & 0x07) )) \
     : "r16" \
 ); \
-while(0)
+} while(0)
 
 #define wdt_disable() \
 do { \
@@ -276,7 +276,7 @@ __asm__ __volatile__ ( \
       [WDVALUE] "n" (1 << WDE) \
     : "r16" \
 ); \
-}while(0)
+} while(0)
 
 #elif defined(CCP)
 


### PR DESCRIPTION
This patchlet fixes inline assembly constraints of `wdt_enable` and `wdt_disable` from `include/avr/wdt.h`.

Some of the operands like `uint8_t temp` are not inputs but are being assigned to in inline asm, so they have to be moved to the ouput operands.

If a register uses `cbr` or `sbr`, then it must be in reg-class upper registers `d`, not general regs `r`.

One `#define` needed wrapping into do-while (or removal of terminal `;`).

