### PR TITLE
Extend _delay_loop_2 so it works with AVR_TINY.

### DIFF
--- a/include/util/delay_basic.h
+++ b/include/util/delay_basic.h
@@ -102,12 +102,20 @@ _delay_loop_1(uint8_t __count)
 void
 _delay_loop_2(uint16_t __count)
 {
+#if defined (__AVR_TINY__)
+	__asm__ volatile (
+		"1: subi %A0,1" "\n\t"
+		"   sbci %B0,0" "\n\t"
+		"brne 1b"
+		: "+d" (__count)
+	);
+#else
 	__asm__ volatile (
 		"1: sbiw %0,1" "\n\t"
 		"brne 1b"
-		: "=w" (__count)
-		: "0" (__count)
+		: "+w" (__count)
 	);
+#endif /* AVR_TINY */
 }
 
 #endif /* _UTIL_DELAY_BASIC_H_ */


### PR DESCRIPTION
This patchlet extends `_delay_loop_2` from `include/util/delay_basic.h` so it also works for AVR_TINY.

AVR_TINY has no `sbiw` instruction, hence reg-class `w` is empty.  We can use `subi+sbci` in that case, which has the same timing but non-empty reg-class `d`.
