### PR TITLE
doc: Note attiny9 being supported

### DIFF
--- a/doc/api/main_page.dox
+++ b/doc/api/main_page.dox
@@ -165,6 +165,7 @@ compile-time.
 
 - attiny4
 - attiny5
+- attiny9
 - attiny10
 - attiny11 \ref supp_dev_footnote_one "[1]"
 - attiny12 \ref supp_dev_footnote_one "[1]"


### PR DESCRIPTION
The attiny9 is the bigger brother of the attiny4 (supported) and the adc-less version of the attiny10 (supported). This looks like an oversight more then anything, as there is also the iotn9.h header.

Documentation change only, no code change.