### PR TITLE
interrupt: Add convenience macros for enable/disable

### DIFF
--- a/include/avr/interrupt.h
+++ b/include/avr/interrupt.h
@@ -64,6 +64,16 @@
 */
 
 #if defined(__DOXYGEN__)
+/** \def interrupts_enable
+    \ingroup avr_interrupts
+
+    Convenience macro that makes code-readability easier over 'sei'. See
+    sei() for details.
+*/
+#endif /* DOXYGEN */
+#define interrupts_enable sei
+
+#if defined(__DOXYGEN__)
 /** \def sei()
     \ingroup avr_interrupts
 
@@ -80,6 +90,16 @@
 #else  /* !DOXYGEN */
 # define sei()  __asm__ __volatile__ ("sei" ::: "memory")
 #endif /* DOXYGEN */
+
+#if defined(__DOXYGEN__)
+/** \def interrupts_enable
+    \ingroup avr_interrupts
+
+    Convenience macro that makes code-readability easier over 'cli'. See
+    cli() for details.
+*/
+#endif /* DOXYGEN */
+#define interrupts_disable cli
 
 #if defined(__DOXYGEN__)
 /** \def cli()


### PR DESCRIPTION
While any seasoned AVR developer should have memorized cli/sei by heart, not everybody is as seasoned or mindful. Further, the three letter accronym also isn't directly discriptive.

Lets introduce a simple macro, similar to 'power_all_disable' etc, to enable/disable interrupts in a more readable way.