### PR TITLE
avrxmega3: fix header installation for attiny424

### DIFF
--- a/include/avr/Makefile.am
+++ b/include/avr/Makefile.am
@@ -280,6 +280,7 @@ avr_HEADERS = \
     iotn814.h \
     iotn816.h \
     iotn817.h \
+    iotn424.h \
     iotn1604.h \
     iotn1606.h \
     iotn1607.h \


### PR DESCRIPTION
Hi,

It appears that the headers for several tiny avrxmega3 devices are not being installed. This pr fixes this for attiny424 but there are probably other devices also similarity impacted