### PR TITLE
Issue #931: Initialize NVMCTRL_CTRLB.FLMAP for Devices that have it.

### DIFF
--- a/crt1/gcrt1.S
+++ b/crt1/gcrt1.S
@@ -244,6 +244,50 @@ __init:
 	out	AVR_RAMPZ_ADDR, __zero_reg__
 #endif
 
+#ifdef __AVR_HAVE_FLMAP__
+	;; Initialize NVMCTRL_CTRLB.FLMAP to __flmap provided not -mrodata-in-ram.
+	;; For interworking of the __flmap* symbols, see Binutils PR31124
+	;; and ./ld/scripttempl/avr.sc.
+
+#if ! defined NVMCTRL_CTRLB || ! defined NVMCTRL_FLMAP_gm \
+    || ! defined NVMCTRL_FLMAP_gp || ! defined NVMCTRL_FLMAPLOCK_bm
+#error unexpected NVMCTRL_CTRLB layout
+#endif /* __AVR_HAVE_FLMAP__ implies NVMCTRL_CTRLB and NVMCTRL_FLMAP_gm */
+
+	;; Defaulting __flmap to the last 32k flash block.
+	;; This is also the hardware default for FLMAP.
+	.weak	__flmap
+	.set	__flmap, (FLASHEND + 1 - 0x8000) >> 15
+	;; Changing FLMAP in the program will invoke UB, hence allow the user
+	;; to set FLMAPLOCK by setting __flmap_lock to non-0.
+	.weak	__flmap_lock
+	.set	__flmap_lock, 0
+	;; Describe positions of FLMAP and mask for FLMAPLOCK in NVMCTRL_CTRLB.
+	;; Mask to lock / protect FLMAP in NVMCTRL_CTRLB provided __flmap_lock.
+	.global	__flmap_lock_mask
+	.set	__flmap_lock_mask, NVMCTRL_FLMAPLOCK_bm
+	;; Bit position of the FLMAP bit field in NVMCTRL_CTRLB.
+	.global	__flmap_bpos
+	.set	__flmap_bpos, NVMCTRL_FLMAP_gp
+
+	;; Conditional RJMP depending on emulation:
+	;; avrxmega[2|4]        ->  __flmap_noinit_start
+	;; avrxmega[2|4]_flmap  ->  __flmap_init_start
+	.global __flmap_init_start
+	.global __flmap_noinit_start
+	rjmp __flmap_init_label     ; Resolves to one of __flmap_[no]init_start
+	__flmap_init_start = .
+	lds r18, NVMCTRL_CTRLB
+#if NVMCTRL_FLMAP_gm == 0x30
+	cbr r18, NVMCTRL_FLMAP_gm
+	ori r18, __flmap_value_with_lock ; |= (__flmap << bpos) | lock_mask
+#else
+#error init FLMAP
+#endif
+	sts NVMCTRL_CTRLB, r18
+	__flmap_noinit_start = .
+#endif /* __AVR_HAVE_FLMAP__ */
+
 #if defined(__GNUC__) && ((__GNUC__ <= 3) || (__GNUC__ == 4 && __GNUC_MINOR__ <= 3))
 #if BIG_CODE
 	/* Only for >64K devices with RAMPZ, replaces the default code

--- a/crt1/gcrt1.S
+++ b/crt1/gcrt1.S
@@ -284,6 +284,11 @@ __init:
 #else
 #error init FLMAP
 #endif
+	;; NVMCTRL_CTRLB is CCP protected with pass-phrase CCP_IOREG_gc = 0xd8.
+    ;; That value is not defined for assembly however, but only as C/C++ enum.
+#ifndef CCP_IOREG_gc
+#define CCP_IOREG_gc 0xd8
+#endif
 	ldi r19, CCP_IOREG_gc
 	out CCP, r19
 	sts NVMCTRL_CTRLB, r18

--- a/crt1/gcrt1.S
+++ b/crt1/gcrt1.S
@@ -284,6 +284,8 @@ __init:
 #else
 #error init FLMAP
 #endif
+	ldi r19, CCP_IOREG_gc
+	out CCP, r19
 	sts NVMCTRL_CTRLB, r18
 	__flmap_noinit_start = .
 

--- a/crt1/gcrt1.S
+++ b/crt1/gcrt1.S
@@ -286,6 +286,25 @@ __init:
 #endif
 	sts NVMCTRL_CTRLB, r18
 	__flmap_noinit_start = .
+
+	;; There may be the case that this crt*.o is used with a toolchain
+	;; that does not support Binutils PR31124.  This can happen when the
+	;; crt*.o is shipped with a device support pack.  In that case, linking
+	;; against crt*.o would raise undefined references to __flmap_init_label
+	;; and __flmap_value_with_lock.  Therefore, provide default values for
+	;; these symbols, which will reduce the negative impact to 5 superfluous
+	;; instructions from above.
+	.weak	__flmap_value_with_lock
+	.set	__flmap_value_with_lock, NVMCTRL_FLMAP_gm
+	;; The linker scripts for emulations avrxmega2/4_flmap define symbol
+	;; __flmap_init_label as PROVIDE, hence a weak definition like below
+	;; would bypass the instructions above.  There is an addendum to PR31124,
+	;; but that's not in v2.42 but only in v2.43 (or v2.42.1).
+	;; In the case when an undefined reference occurs, a work-around is to
+	;; -Wl,--defsym,__flmap_init_label=__flmap_noinit_start
+	;; or to achieve the same by defining the symbol in assembly like below.
+	;.weak	__flmap_init_label
+	;.set	__flmap_init_label, __flmap_noinit_start
 #endif /* __AVR_HAVE_FLMAP__ */
 
 #if defined(__GNUC__) && ((__GNUC__ <= 3) || (__GNUC__ == 4 && __GNUC_MINOR__ <= 3))


### PR DESCRIPTION
```none
Issue #931: Initialize NVMCTRL_CTRLB.FLMAP for Devices that have it.

https://sourceware.org/PR31124
https://gcc.gnu.org/PR112944
support locating .rodata in program memory for some devices from the
avrxmega2 (AVR64*) and avrxmega4 (AVR128*) families.

The user can chose the 32 KiB flash block which hosts the .rodata section
by means of defining symbol __flmap.  Or they can return to the old layout
with .rodata in RAM by means of compiler option -mrodata-in-ram.

In the rodata-in-flash case, the startup code in .init2 sets bit-field
NVMCTRL_CTRLB.FLMAP to __flmap.  In the rodata-in-ram case, the startup
code leaves NVMCTRL_CTRLB alone.  The decision is taken by a
conditional RJMP, so that the same crt<mcu>.o serves both cases.

The user can also chose to lock the FLMAP bit-field from further changes
by defining symbol __flmap_lock to a non-0 value.

The code sequence in .init2 will only be activated when __AVR_HAVE_FLMAP__
is defined, which is only the case when avr-gcc implements PR112944, and
avr-ld implements PR31124.

	* crt1/gcrt1.S (section .init2) [__AVR_HAVE_FLMAP__]:
	Weakly define __flmap and __flmap_lock.
	Define global symbols __flmap_init_start and __flmap_noinit_start.
	Initialize NVMCTRL_CTRLB.FLMAP to __flmap.
	Initialize NVMCTRL_CTRLB.FLMAPLOCK to __flmap_lock.
	Define global symbols __flmap_lock_mask and __flmap_bpos which
	describe the layout of FLMAP and FLMAPLOCK in NVMCTRL_CTRLB.
```
https://sourceware.org/PR31124 and
https://gcc.gnu.org/PR112944
support rodata in flash for devices from the AVR64* and AVR128* families.

The 32 KiB flash block that's visible in the RAM address space can be selected by setting `NVMCTRL_CTRLB.FLMAP` to the desired value. The default linker scripts for `-mno-rodata-in-ram` (the avr-gcc default) will locate rodata in flash.

The hardware default for FLAMP is the last 32 KiB block, so that the code from Binutils and GCC works with the default layout of using the last 32 KiB block. The addition to `gcrt1.S` is required:
* When the user wants to use a different 32 KiB block, and / or
* The user wants to lock FLMAP from further changes.

In the proposed patch, the default for `__flmap_lock` is true, which might be overly conservative. In that case, we can default is to false instead.

When the user chose `-mrodata-in-ram`, then the code to set up FLAMP and FLMAPLOCK is bypassed by a conditional RJMP that resolves depending on `-m[no-]rodata-in-ram`. Technically, the resolution of the RJMP target depends on which emulation is used. For a documentation of the involved symbols, see  [PR31124](https://sourceware.org/bugzilla/show_bug.cgi?id=31124#c3).

