### PR TITLE
Issue #936: Provide symbols for exact memory layout.

### DIFF
--- a/crt1/gcrt1.S
+++ b/crt1/gcrt1.S
@@ -386,12 +386,48 @@ __do_copy_data:
 .L__desc_end:
     .balign 4
 
-  /* Set REGION_LENGTH symbol values for well known memory regions.
-  The default linker script uses these symbols to set MEMORY 
-  region lengths, and by defining these here, the linker can detect
-  memory overflows accurately on a per device basis, since the 
-  values are picked up from the device header file.
-  */
 
-  .weak __FUSE_REGION_LENGTH__
-  .set __FUSE_REGION_LENGTH__, FUSE_MEMORY_SIZE
+/* Set REGION_LENGTH symbol values for well known memory regions.
+   The default linker script uses these symbols to set MEMORY
+   region lengths, and by defining these here, the linker can detect
+   memory overflows accurately on a per device basis, since the
+   values are picked up from the device header file.  */
+
+.weak __FUSE_REGION_LENGTH__
+.set  __FUSE_REGION_LENGTH__, FUSE_MEMORY_SIZE
+
+#if defined (FLASHEND)
+#if ! defined FLASHSTART
+#define FLASHSTART 0
+#endif
+    ;; Some of the Automotive devices have Flash start at 0x8000,
+    ;; but MEMORY region text starts at __TEXT_REGION_ORIGIN__ only
+    ;; since Binutils PR31177 (v2.42 released 2024).  Older versions
+    ;; of Binutils have text region start hard coded as 0x0.
+    ;; Therefore, only provide strict region layout for devices where
+    ;; program memory starts at 0x0.
+#if FLASHSTART == 0
+    .weak __TEXT_REGION_ORIGIN__
+    .set  __TEXT_REGION_ORIGIN__, (FLASHSTART)
+    .weak __TEXT_REGION_LENGTH__
+    .set  __TEXT_REGION_LENGTH__, 1 + (FLASHEND) - (FLASHSTART)
+#endif /* FLASHSTART == 0 */
+#endif /* FLASHEND */
+
+;; The RAM virtual memory address used by Binutils to linearize memory.
+#define RAM_VMA 0x800000
+
+#if defined (RAMSTART) && defined (RAMEND)
+    .weak __DATA_REGION_ORIGIN__
+    .set  __DATA_REGION_ORIGIN__, (RAM_VMA) | (RAMSTART)
+    .weak __DATA_REGION_LENGTH__
+    .set  __DATA_REGION_LENGTH__, 1 + (RAMEND) - (RAMSTART)
+#endif /* have RAMSTART and RAMEND */
+
+#if defined (EEPROM_SIZE) && (EEPROM_SIZE) > 0
+    .weak __EEPROM_REGION_LENGTH__
+    .set  __EEPROM_REGION_LENGTH__, EEPROM_SIZE
+#elif defined (E2END) && (E2END) > 0
+    .weak __EEPROM_REGION_LENGTH__
+    .set  __EEPROM_REGION_LENGTH__, 1 + (E2END)
+#endif /* E2END > 0 */


### PR DESCRIPTION
The linker can produce more exact diagnostics, when the properties of the MEMORY regions as described in the linker description files are matching the memories available in the hardware.

This is currently not the case: The defaults for the text region and for the data region pretend vastly more memory than is actually available.

The canonical place to define respective symbols, which are used by the default linker scripts, is the startup code in gcrt1.S.

	* crt1/gcrt1.S (__TEXT_REGION_ORIGIN__, __TEXT_REGION_LENGTH__) (__DATA_REGION_ORIGIN__, __DATA_REGION_LENGTH__): Weakly define symbols provided information is available (FLASHEND, RAMEND, RAMSTART).