### PR TITLE
Issue 940 runtest

### DIFF
--- a/tests/simulate/regression/bug-25723.c
+++ b/tests/simulate/regression/bug-25723.c
@@ -38,6 +38,8 @@
 /*
  * Test code from bug #25723, courtesy Lou Amadio.
  */
+void *ptr;
+
 void testMalloc(void)
 {
     size_t *array = malloc(4 * sizeof(size_t));
@@ -47,7 +49,7 @@ void testMalloc(void)
     array = realloc(array, sizeof(size_t));
     array = realloc(array, 2 * sizeof(size_t));
     array = realloc(array, 3 * sizeof(size_t));
-    realloc(array, 4 * sizeof(size_t));
+    ptr = realloc(array, 4 * sizeof(size_t));
 }
 
 int

--- a/tests/simulate/stdlib/malloc-5.c
+++ b/tests/simulate/stdlib/malloc-5.c
@@ -54,6 +54,9 @@ extern struct __freelist *__flp; /* freelist pointer (head of freelist) */
 extern char *__malloc_heap_start;
 extern char *__malloc_heap_end;
 
+#if __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
 int main(void)
 {
     void *ptrs[6];

--- a/tests/simulate/stdlib/malloc-6.c
+++ b/tests/simulate/stdlib/malloc-6.c
@@ -54,6 +54,9 @@ extern struct __freelist *__flp; /* freelist pointer (head of freelist) */
 extern char *__malloc_heap_start;
 extern char *__malloc_heap_end;
 
+#if __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
 int main(void)
 {
     void *ptrs[6];

--- a/tests/simulate/stdlib/setjmp-3.c
+++ b/tests/simulate/stdlib/setjmp-3.c
@@ -63,6 +63,7 @@ int main ()
 		break;
 	    case 0:
 		foo ();
+		/* fallthrough */
 	    default:
 		exit (__LINE__);
 	}

--- a/tests/simulate/stdlib/strtol-4.c
+++ b/tests/simulate/stdlib/strtol-4.c
@@ -80,12 +80,14 @@ int main ()
 	sprintf(s, "%ld", x);
 	if (t_strtol(s, 0, x, 0, strlen(s)))
 	    exit(__LINE__);
-	sprintf(s, "-%lx", -x);
-	if (t_strtol(s, 16, x, 0, strlen(s)))
-	    exit(__LINE__);
-	sprintf(s, "-%lo", -x);
-	if (t_strtol(s, 8, x, 0, strlen(s)))
-	    exit(__LINE__);
+	if (x != LONG_MIN) {
+	    sprintf(s, "-%lx", -x);
+	    if (t_strtol(s, 16, x, 0, strlen(s)))
+		exit(__LINE__);
+	    sprintf(s, "-%lo", -x);
+	    if (t_strtol(s, 8, x, 0, strlen(s)))
+		exit(__LINE__);
+	}
     }
     
     for (x = 1; x <= 300; x++) {

--- a/tests/simulate/stdlib/utoa-3.c
+++ b/tests/simulate/stdlib/utoa-3.c
@@ -108,42 +108,42 @@ int main ()
 
 	for (i = 0; i < 16; i++) {
 	    CHECK (1 << i, radix);
-	    CHECK (~0 << i, radix);
+	    CHECK (~0u << i, radix);
 	}
 
 	for (i = 0; i < 15; i++) {
 	    CHECK (3 << i, radix);
-	    CHECK (~3 << i, radix);
+	    CHECK (~3u << i, radix);
 	}
 
 	for (i = 0; i < 14; i++) {
 	    CHECK (7 << i, radix);
-	    CHECK (~7 << i, radix);
+	    CHECK (~7u << i, radix);
 	}
 
 	for (i = 0; i < 13; i++) {
 	    CHECK (017 << i, radix);
-	    CHECK (~017 << i, radix);
+	    CHECK (~017u << i, radix);
 	}
 
 	for (i = 0; i < 12; i++) {
 	    CHECK (037 << i, radix);
-	    CHECK (~037 << i, radix);
+	    CHECK (~037u << i, radix);
 	}
 
 	for (i = 0; i < 11; i++) {
 	    CHECK (077 << i, radix);
-	    CHECK (~077 << i, radix);
+	    CHECK (~077u << i, radix);
 	}
 
 	for (i = 0; i < 10; i++) {
 	    CHECK (0177 << i, radix);
-	    CHECK (~0177 << i, radix);
+	    CHECK (~0177u << i, radix);
 	}
 
 	for (i = 0; i < 9; i++) {
 	    CHECK (0377 << i, radix);
-	    CHECK (~0377 << i, radix);
+	    CHECK (~0377u << i, radix);
 	}
 
 	n = radix*radix;


### PR DESCRIPTION
This pull-request is about:

* Adjusting `runtest.sh` to the new layout of the build tree:
  * `crt*.o` are located in `avr/devices`, no more in `avr/lib`:
  * Build tree uses flattened multilib paths, e.g. `avr25_tiny_stack` instead of `av25/tiny-stack`.
  * Compile with `-Wno-array-bounds` to work around the many false warnings due to [PR105523](https://gcc.gnu.org/PR105523).
* Fix code that would invoke Undefined Behaviour.
* Fix some warning in test cases: Use the result of `realloc`. Mark fallthrough cases as `fallthrough`.
* Disable `-Wuse-after-free` for test cases that use a pointer value after it has been `free`'d.
