### PR TITLE
Issue #962 - libm: Use ELPM for tables on ELPM devices.

### DIFF
--- a/libm/fplib/asin.S
+++ b/libm/fplib/asin.S
@@ -57,6 +57,7 @@ ENTRY_FLOAT asinf asin asinl
   ; for small x
 	ldi	ZL, lo8 (.L_table)
 	ldi	ZH, hi8 (.L_table)
+	LDI_XH_hh8(.L_table)
 	XCALL	_U(__fp_powsodd)
 	rjmp	2f
   ; arcsin(x) = Pi/2 - arccos(x)
@@ -76,7 +77,7 @@ ENTRY_FLOAT asinf asin asinl
 	ret
 ENDFUNC
 
-	PGM_SECTION
+	PGMX_SECTION(.asin)
 .L_table:
 	.byte	3
 	.byte	     0x6e,0xdb,0x36,0x3d	; 15/336

--- a/libm/fplib/atan.S
+++ b/libm/fplib/atan.S
@@ -77,6 +77,7 @@ ENTRY_FLOAT atanf atan atanl
 	XCALL	_U(squaref)
 	ldi	ZL, lo8(.L_table)
 	ldi	ZH, hi8(.L_table)
+	LDI_XH_hh8(.L_table)
 	XCALL	_U(__fp_powser)
 	XCALL	_U(__fp_round)
 	pop	rB0
@@ -102,7 +103,7 @@ ENTRY_FLOAT atanf atan atanl
 	XJMP	_U(__fp_round)
 ENDFUNC
 
-	PGM_SECTION
+	PGMX_SECTION(.atan)
 .L_table:
 	.byte	8
 	.byte	     0x4a,0xd7,0x3b,0x3b	;  0.0028662257

--- a/libm/fplib/exp.S
+++ b/libm/fplib/exp.S
@@ -81,6 +81,7 @@ ENTRY_FLOAT expf exp expl
   ; calculate 2**(-x) for 0 <= x < 1
 	ldi	ZL, lo8(.L_table)
 	ldi	ZH, hi8(.L_table)
+	LDI_XH_hh8(.L_table)
 	XCALL	_U(__fp_powser)
   ; get integral part
 	pop	exp_lo
@@ -110,7 +111,7 @@ ENTRY_FLOAT expf exp expl
 	ret
 ENDFUNC
 
-	PGM_SECTION
+	PGMX_SECTION(.exp)
 .L_table:
 	.byte	7
 	.byte	     0x63,0x42,0x36,0xb7	; -0.0000108635

--- a/libm/fplib/fp32def.h
+++ b/libm/fplib/fp32def.h
@@ -24,8 +24,17 @@
 #endif
 #define FUNC_SEGNAME	MLIB_SECTION
 
-/* Put constant tables at low addresses in program memory, so they are
-   reachable for "lpm" without using RAMPZ on >64K devices.  */
-#define PGM_SECTION	.section  .progmem.gcc_fplib, "a", @progbits
+/* Put constant tables in .progmemx in program memory, so they
+   don't nibble on the lower 64K PROGMEM.  */
+#define PGMX_SECTION(x)	.section .progmemx.gcc_fplib##x, "a", @progbits
+
+#ifdef __AVR_HAVE_ELPM__
+#  if !defined(AVR_RAMPZ_ADDR)
+#  define AVR_RAMPZ_ADDR 0x3b
+#  endif
+#  define LDI_XH_hh8(sym)	ldi XH, hh8(sym)
+#else /* ELPM ? */
+#  define LDI_XH_hh8(sym)	/* empty */
+#endif /* ELPM ? */
 
 #endif	/* !_FP32DEF_H */

--- a/libm/fplib/fp_arccos.S
+++ b/libm/fplib/fp_arccos.S
@@ -60,6 +60,7 @@ ENTRY __fp_arccos
 
 	ldi	ZL, lo8(.L_table)
 	ldi	ZH, hi8(.L_table)
+	LDI_XH_hh8(.L_table)
 	XCALL	_U(__fp_powser)
 	XCALL	_U(__fp_round)
 
@@ -96,6 +97,7 @@ ENTRY __fp_arccos
   ; calculate: C0 + A*(C1 + ...)
 	ldi	ZL, lo8(.L_table)
 	ldi	ZH, hi8(.L_table)
+	LDI_XH_hh8(.L_table)
 	XCALL	_U(__fp_powser)
 	XCALL	_U(__fp_round)
   ; restore A
@@ -125,7 +127,7 @@ ENTRY __fp_arccos
 #endif
 ENDFUNC
 
-	PGM_SECTION
+	PGMX_SECTION(.arccos)
 .L_table:
 	.byte	7
 	.byte	     0x2c,0x7a,0xa5,0xba	; -0.0012624911

--- a/libm/fplib/fp_powser.S
+++ b/libm/fplib/fp_powser.S
@@ -34,12 +34,13 @@
 #include "fp32def.h"
 #include "asmdef.h"
 
-/* flt40_t __fp_powser (float x, ZH.ZL);
+/* flt40_t __fp_powser (float x, [XH.]ZH.ZL);
      The __fp_powser() function calculates the polynom.
 
    Input:
      rA3.rA2.rA1.rA0	- an 'x' arg
-     ZH.ZL		- table address (in low 64K flash memory)
+     ZH.ZL		- table address
+     XH			- hh8(table address) on ELPM devices
    Output:
      rA3.rA2.rA1.rA0.rAE - result (is't rounded)
 
@@ -59,6 +60,25 @@
 #define	rC0	r14
 #define	rcntr	r13
 
+
+.macro .ELPM_Zplus reg
+#ifdef __AVR_HAVE_ELPMX__
+	elpm	\reg, Z+
+#elif defined(__AVR_HAVE_ELPM__)
+        elpm
+	mov	\reg, r0
+        adiw	r30, 1
+        brcc    .Lnoinc.\@
+	in	r0, AVR_RAMPZ_ADDR
+        inc	r0
+	out	AVR_RAMPZ_ADDR, r0
+.Lnoinc.\@:
+#else
+	X_lpm	\reg, Z+
+#endif
+.endm
+
+
 ENTRY __fp_powser
 	push	YH
 	push	YL
@@ -67,7 +87,9 @@ ENTRY __fp_powser
 	push	rC1
 	push	rC0
 	push	rcntr
-
+#ifdef __AVR_HAVE_ELPM__
+	out	AVR_RAMPZ_ADDR, XH
+#endif
 	X_movw	rC0, rA0
 	X_movw	rC2, rA2
 
@@ -81,11 +103,11 @@ ENTRY __fp_powser
 
 	clt
 .Load5:
-	X_lpm	rBE, Z+
-	X_lpm	rB0, Z+
-	X_lpm	rB1, Z+
-	X_lpm	rB2, Z+
-	X_lpm	rB3, Z+
+	.ELPM_Zplus	rBE
+	.ELPM_Zplus	rB0
+	.ELPM_Zplus	rB1
+	.ELPM_Zplus	rB2
+	.ELPM_Zplus	rB3
 	brts	1b
 
 	X_movw	YL, ZL
@@ -104,6 +126,9 @@ ENTRY __fp_powser
 	pop	rC3
 	pop	YL
 	pop	YH
+#if defined(__AVR_HAVE_ELPM__) && defined (__AVR_HAVE_RAMPD__)
+	out	AVR_RAMPZ_ADDR, r1
+#endif
 	ret
 ENDFUNC
 

--- a/libm/fplib/fp_powsodd.S
+++ b/libm/fplib/fp_powsodd.S
@@ -32,13 +32,14 @@
 #include "fp32def.h"
 #include "asmdef.h"
 
-/* float __fp_powsodd (float A, ZH.ZL);
+/* float __fp_powsodd (float A, [XH.]ZH.ZL);
      The __fp_powsodd() function calculates a polynom with only odd
      powers of x.  Result is rounded.
 
    Input:
      rA3.rA2.rA1.rA0	- an 'x' arg
-     ZH.ZL		- table address (in flash low 64K memory)
+     ZH.ZL		- table address in flash
+     XH			- hh8(table address) on ELPM devices
 
    Notes:
      * As __fp_powsodd() is one of base function, square() is't used.
@@ -51,6 +52,9 @@ ENTRY __fp_powsodd
 	push	rA1
 	push	rA0
 
+#ifdef __AVR_HAVE_ELPM__
+	push	XH
+#endif
 	push	ZH
 	push	ZL
 
@@ -60,6 +64,9 @@ ENTRY __fp_powsodd
 
 	pop	ZL
 	pop	ZH
+#ifdef __AVR_HAVE_ELPM__
+	pop	XH
+#endif
 	XCALL	_U(__fp_powser)
 
 	pop	rB0

--- a/libm/fplib/fp_sinus.S
+++ b/libm/fplib/fp_sinus.S
@@ -61,10 +61,11 @@ ENTRY __fp_sinus
 
 	ldi	ZL, lo8(.L_table)
 	ldi	ZH, hi8(.L_table)
+	LDI_XH_hh8(.L_table)
 	XJMP	_U(__fp_powsodd)
 ENDFUNC
 
-	PGM_SECTION
+	PGMX_SECTION(.sinus)
 .L_table:
 	.byte	5
 	.byte	     0xa8,0x4c,0xcd,0xb2	; -0.0000000239

--- a/libm/fplib/log.S
+++ b/libm/fplib/log.S
@@ -96,10 +96,12 @@ ENTRY_FLOAT logf log logl
 3:	XCALL	_U(__addsf3)
 	ldi	ZL, lo8(.L_tlow)
 	ldi	ZH, hi8(.L_tlow)
+	LDI_XH_hh8(.L_tlow)
 	rjmp	5f
 4:	XCALL	_U(__addsf3)
 	ldi	ZL, lo8(.L_thigh)
 	ldi	ZH, hi8(.L_thigh)
+	LDI_XH_hh8(.L_thigh)
 5:	XCALL	_U(__fp_powser)
 
 	X_movw	rC0, rA0
@@ -134,7 +136,7 @@ ENTRY_FLOAT logf log logl
 	XJMP	_U(__fp_round)
 ENDFUNC
 
-	PGM_SECTION
+	PGMX_SECTION(.log)
 
 .L_tlow:		; __fp_powser() table for small values
 	.byte	8

--- a/libm/fplib/sinh.S
+++ b/libm/fplib/sinh.S
@@ -59,6 +59,7 @@ ENTRY_FLOAT sinhf sinh sinhl
   ; for small x
 	ldi	ZL, lo8(.L_table)
 	ldi	ZH, hi8(.L_table)
+	LDI_XH_hh8(.L_table)
 	XCALL	_U(__fp_powsodd)
 	rjmp	2f
   ; expf(-fabsf(x))	// negative to exclude an extra inversion
@@ -91,7 +92,7 @@ ENTRY_FLOAT sinhf sinh sinhl
 	ret
 ENDFUNC
 
-	PGM_SECTION
+	PGMX_SECTION(.sinh)
 .L_table:
 	.byte	2
 	.byte	     0x89,0x88,0x08,0x3c	; 1/120

--- a/libm/fplib/tan.S
+++ b/libm/fplib/tan.S
@@ -86,6 +86,7 @@ ENTRY_FLOAT tanf tan tanl
   ; calculate tan(A) for  0 <= A <= Pi/4
 1:	ldi	ZL, lo8(.L_table)
 	ldi	ZH, hi8(.L_table)
+	LDI_XH_hh8(.L_table)
 	XCALL	_U(__fp_powsodd)
   ; correct result
 	lsl	rsign
@@ -98,7 +99,7 @@ ENTRY_FLOAT tanf tan tanl
 	ret
 ENDFUNC
 
-	PGM_SECTION
+	PGMX_SECTION(.tan)
 .L_table:
 	.byte	6
 	.byte	     0x64,0xec,0x1b,0x3c	;  0.0095168091

--- a/libm/fplib/tanh.S
+++ b/libm/fplib/tanh.S
@@ -64,6 +64,7 @@ ENTRY_FLOAT tanhf tanh tanhl
   ; for small x
 	ldi	ZL, lo8(.L_table)
 	ldi	ZH, hi8(.L_table)
+	LDI_XH_hh8(.L_table)
 	XCALL	_U(__fp_powsodd)
 	rjmp	2f
   ; exp(-2*fabs(x))
@@ -110,7 +111,7 @@ ENTRY_FLOAT tanhf tanh tanhl
 	ret
 ENDFUNC
 
-	PGM_SECTION
+	PGMX_SECTION(.tanh)
 .L_table:
 	.byte	2
 	.byte	     0x89,0x88,0x08,0x3e	; 2/15


### PR DESCRIPTION
Put libm lookup tables into section .progmemx instead of in section .progmem.  On ELPM devices, use register XH to pass the hh8() part of the table address to __fp_powser / __fp_powsodd.

	* libm/fplib/fp32def.h (AVR_RAMPZ_ADDR, LDI_XH_hh8): New macros. (PGMX_SECTION): New macro, replacing PGM_SECTION,
	* libm/fplib/fp_powser.S (.ELPM_Zplus): New .macro. (__fp_powser): Use .ELPM_Zplus instead of X_lpm. [have ELPM]: Set/restore RAMPZ as needed.
	* libm/fplib/fp_powsodd.S (__fp_powsodd) [have ELPM]: Push/pop XH around __mulsf3.
	* libm/fplib/asin.S [have ELPM]: Pass hh8() of table in XH. Put table(s) in .progmemx.gcc_fplib.* section.
	* libm/fplib/atan.S: Same.
	* libm/fplib/exp.S: Same.
	* libm/fplib/log.S: Same.
	* libm/fplib/fp_arccos.S: Same.
	* libm/fplib/fp_sinus.S: Same.
	* libm/fplib/sinh.S: Same.
	* libm/fplib/tan.S: Same.
	* libm/fplib/tanh.S: Same.