### PR TITLE
Issue #971 - configure.ac: Test for Binutils PR29741 / PR31177.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,18 @@
 
 * Issues closed:
 
+  - Since v2.2.0 (Issue #936), gcrt1.S defines symbols __DATA_REGION_ORIGIN__
+    and __DATA_REGIO_LENGTH__ to allow for more precise diagnostics from
+    the linker when the data region overflows.  However, letting .data start
+    at __DATA_REGION_ORIGIN__ is a relatively new addition in Binutils v2.40
+    PR29741, whereas using __DATA_REGION_LENGTH__ for .data size is a much
+    older addition.  Outcome may be that the linker script adopts the true
+    size of .data but not its start address, resulting in incorrect errors
+    from the linker (Issue #971).  In order to resolve #971, a configure
+    test has been added that checks for PR29741, and only defines the mentioned
+    symbols when PR29741 is available.  A similar test has been added for
+    PR31177 which is a similar feature for the .text region.
+
   - On Reduced Tiny, add 0x4000 to the symbol address when
     pgm_get_far_address() takes the address of an object in PROGMEM_FAR.
     This works similar to how the compiler implements the &-operator

--- a/configure.ac
+++ b/configure.ac
@@ -138,9 +138,11 @@ m4_if(m4_defn([m4_PACKAGE_VERSION]), [2.64],
 
 AC_PROG_CC
 AC_CHECK_TOOL(AS, as, as)
+AC_CHECK_TOOL(LD, ld, ld)
 AM_PROG_AS
 AC_PROG_RANLIB
 AC_CHECK_TOOL(AR, ar, ar)
+AC_CHECK_TOOL(OBJDUMP, objdump, objdump)
 
 # Make sure that we found the right avr cross-compiler.
 
@@ -157,6 +159,14 @@ case "${AS}" in
    *avr*as*) ;;
    *) AC_MSG_ERROR(Wrong assembler found; check the PATH!) ;;
 esac
+case "${LD}" in
+   *avr*ld*) ;;
+   *) AC_MSG_ERROR(Wrong linker found; check the PATH!) ;;
+esac
+case "${OBJDUMP}" in
+   *avr*objdump*) ;;
+   *) AC_MSG_ERROR(Wrong objdump found; check the PATH!) ;;
+esac
 case "${AR}" in
    *avr*ar*) ;;
    *) AC_MSG_ERROR(Wrong archiver found; check the PATH!) ;;
@@ -169,6 +179,44 @@ esac
 AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
+
+
+dnl $1 = MSG_CHECKING
+dnl Assemble and link assembly source $2 with extra $AS options $3
+dnl and extra $LD options $4.  When pattern $5 is found in `objdump -h`,
+dnl then run $6, else run $7.
+AC_DEFUN([CHECK_OBJDUMP_MINUS_H],[dnl
+AC_MSG_CHECKING($1)
+rm -f conftest.s conftest.o conftest.elf conftest.lst
+cat > conftest.s <<EOF
+$2
+EOF
+AC_TRY_COMMAND([$AS conftest.s $3 -o conftest.o])
+AC_TRY_COMMAND([$LD conftest.o $4 -o conftest.elf])
+AC_TRY_COMMAND([$OBJDUMP -h conftest.elf > conftest.lst])
+AS_IF([grep $5 conftest.lst > /dev/null],has_pat=yes,has_pat=no)
+AC_MSG_RESULT($has_pat)
+AS_IF([test "x$has_pat" = "xyes"], [$6], [$7])
+rm -f conftest.s conftest.o conftest.elf conftest.lst
+])
+
+dnl Outcome is consumed by crt1/gcrt1.S
+CHECK_OBJDUMP_MINUS_H([whether data region starts at __DATA_REGION_ORIGIN__],dnl
+    [.data],dnl
+    [-mmcu=avr2], [-mavr2 --defsym __DATA_REGION_ORIGIN__=0x800066],
+    ['\.data.*00800066'],
+    AC_DEFINE([HAVE_LDSCRIPT_PR29741], 1,
+        [Define if the ld script uses __DATA_REGION_ORIGIN__ as data start.]),
+)
+
+dnl Outcome is consumed by crt1/gcrt1.S
+CHECK_OBJDUMP_MINUS_H([whether text region starts at __TEXT_REGION_ORIGIN__],dnl
+    [.data],dnl
+    [-mmcu=avr2], [-mavr2 --defsym __TEXT_REGION_ORIGIN__=0x22],
+    ['\.text.*00000022'],
+    AC_DEFINE([HAVE_LDSCRIPT_PR31177], 1,
+        [Define if the ld script uses __TEXT_REGION_ORIGIN__ as text start.]),
+)
 
 
 dnl Substitute $1 with the basenames of all files in glob $2.

--- a/crt1/gcrt1.S
+++ b/crt1/gcrt1.S
@@ -38,6 +38,8 @@
 #include IOSYMFILE
 
 #include "macros.inc"
+#include "config.h"
+
 ;; Use _VECTOR_SIZE from the I/O header which might be more reliable than
 ;; using macros.inc's XJMP according to __AVR_HAVE_JMP_CALL__.  As an example,
 ;; take ATmega808 which avr-gcc lists as short-calls and thus with a vector
@@ -403,7 +405,7 @@ __do_copy_data:
     ;; of Binutils have text region start hard coded as 0x0.
     ;; Therefore, only provide strict text region layout for devices
     ;; where program memory starts at 0x0.
-#if FLASHSTART == 0
+#if FLASHSTART == 0 || defined (HAVE_LDSCRIPT_PR31177)
     .weak __TEXT_REGION_ORIGIN__
     .set  __TEXT_REGION_ORIGIN__, (FLASHSTART)
     .weak __TEXT_REGION_LENGTH__
@@ -414,13 +416,13 @@ __do_copy_data:
 ;; The RAM virtual memory address used by Binutils to linearize memory.
 #define RAM_VMA 0x800000
 
-#if defined (RAMSTART) && defined (RAMEND)
-    ;; __DATA_REGION_ORIGIN__ is used since ld v2.40 / 2023-01-14 / PR29741.
-    ;; Prior to that, a core specific default value $DATA_ORIGIN was used.
-    ;; __DATA_REGION_LENGTH__ however is in use since 2015 / cb0728165e282b
-    ;; which means that with Binutils older than v2.40, we may get a
-    ;;    ld: address <X> of <FILE> section `.data' is not within region `data'
-    ;; error from the linker when $DATA_ORIGIN is not __DATA_REGION_ORIGIN__.
+;; __DATA_REGION_ORIGIN__ is used since ld v2.40 / 2023-01-14 / PR29741.
+;; Prior to that, a core specific default value $DATA_ORIGIN was used.
+;; __DATA_REGION_LENGTH__ however is in use since 2015 / cb0728165e282b
+;; which means that with Binutils older than v2.40, we may get a
+;;    ld: address <X> of <FILE> section `.data' is not within region `data'
+;; error from the linker when $DATA_ORIGIN is not __DATA_REGION_ORIGIN__.
+#if defined (RAMSTART) && defined (RAMEND) && defined (HAVE_LDSCRIPT_PR29741)
     .weak __DATA_REGION_ORIGIN__
     .set  __DATA_REGION_ORIGIN__, (RAM_VMA) | (RAMSTART)
     .weak __DATA_REGION_LENGTH__


### PR DESCRIPTION
Since v2.2.0's implementation of issue #936, gcrt1.S defines symbols `__DATA_REGION_ORIGIN__` and `__DATA_REGION_LENGTH__`.

These symbols are used in the default linker scripts to define the beginning and extent of the data memory region -- but only since the recent implementation of PR29741 in Binutils v2.40.  Prior to that, the data region started at a core specific value of $DATA_ORIGIN together with a length of `__DATA_REGION_LENGTH__`.

Outcome was that #936 may set the data region length to the correct length, but misses to set data origin as the linker script does not use `__DATA_REGION_ORIGIN__`.  This lead to errors from the linker when user data starting at -Tdata extended beyond $DATA_ORIGIN + `__DATA_REGION_LENGTH__`.

This patch adds a configure test for ld script features: Binutils PR29741: Uses `__DATA_REGION_ORIGIN__` for data region start, and Binutils PR31177: Uses `__TEXT_REGION_ORIGIN__` for test region start. This is accomplished by examining the output of objdump -h.
```
	* configure.ac (AC_CHECK_TOOL): Add one for: LD, OBJDUMP. (CHECK_OBJDUMP_MINUS_H): New AC_DEFUN. (HAVE_LDSCRIPT_PR29741): AC_DEFINE depending on Binutls PR29741. (HAVE_LDSCRIPT_PR31177): AC_DEFINE depending on Binutls PR31177.
	* crt1/gcrt1.S (config.h): Include it. (__DATA_REGION_ORIGIN__, __DATA_REGION_LENGTH__): Only define if HAVE_LDSCRIPT_PR29741. (__TEXT_REGION_ORIGIN__, __TEXT_REGION_LENGTH__): Also define if HAVE_LDSCRIPT_PR31177.
```