### PR TITLE
definition of `sig_atomic_t` in `signal.h`

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -12,7 +12,7 @@ extern sighandler_t signal(int signum, sighandler_t handler);
 #define SIG_HOLD ((sighandler_t)((void*)signal+2))
 #define SIG_IGN  ((sighandler_t)((void*)signal+3))
 
-volatile signed char sig_atomic_t;
+typedef signed char sig_atomic_t;
 typedef int sigset_t;
 
 extern int raise(int sig);


### PR DESCRIPTION
Hey,

I think I've found a small bug in the definition of `sig_atomic_t`.
Try this code example and it never compiles:

```
// File fun_signal.c
#include <signal.h>

sighandler_t signal( int signum, sighandler_t handler ) {
    ( ( void ) signum );
    // do nothing
    return handler;
}

// File main.c
#include <signal.h>
#include <stdlib.h>

#define SIGERR ( 13 )

void err_handler( int num ) {
    ( ( void ) num );
    exit( EXIT_FAILURE );
}

int main( void ) {
    signal( SIGERR, err_handler );

    return EXIT_SUCCESS;
}
```

compile for example with:
```
$ avr-gcc -mmcu=atmega328p fun_signal.c main.c                               
/usr/libexec/gcc/avr/ld: /tmp/ccA4lgNc.o:(.bss+0x0): multiple definition of `sig_atomic_t'; /tmp/ccCDOhhx.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
```

To solve the problem, sig_atomic_t must defined correctly.