### PR TITLE
fix misspelled symbol names and comments

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,7 +14,7 @@
 * Issues closed:
 
   - Since v2.2.0 (Issue #936), gcrt1.S defines symbols __DATA_REGION_ORIGIN__
-    and __DATA_REGIO_LENGTH__ to allow for more precise diagnostics from
+    and __DATA_REGION_LENGTH__ to allow for more precise diagnostics from
     the linker when the data region overflows.  However, letting .data start
     at __DATA_REGION_ORIGIN__ is a relatively new addition in Binutils v2.40
     PR29741, whereas using __DATA_REGION_LENGTH__ for .data size is a much
@@ -137,7 +137,7 @@
     Notice that only since Binutils v2.29 (PR21849), section .progmemx is
     located after the .text sections.
 
-  - The startup code now defines symbols like __DATA_REGION__LENGTH__ and
+  - The startup code now defines symbols like __DATA_REGION_LENGTH__ and
     __DATA_REGION_ORIGIN__ according to the memories of the used AVR device
     (Issue #936).  These symbols are used by the default linker scripts to
     diagnose when the text or data region overflows.
@@ -147,7 +147,7 @@
   - The pgm_read_* and pgm_read_*_far macros and functions now also work for
     the Reduced Tiny devices. (Issue #563).  The implementation assumes that
     GCC implements PR71948 which was added in v7.  Notice that on Reduced Tiny:
-    * There is no need for PROGEMM at all because all const objects in static
+    * There is no need for PROGEM at all because all const objects in static
       storage are located in program memory since Binutils v2.27 (PR20849).
     * Even when PROGMEM is used, no pgm_read functions or macros are required.
       See the GCC documentation on the __progmem__ attribute for Reduced Tiny.
@@ -196,7 +196,7 @@
   - Issue #936: Provide symbols for exact memory layout. enhancement [#937]
   - Issue #931: Initialize NVMCTRL_CTRLB.FLMAP for Devices that have it. enhancement [#935]
   - Issue #931: Initialize NVMCTRL_CTRLB.FLMAP for Devices that have it. [#933]
-  - Issue 929: Remove __ATTR_CONST__ from frexp* protoypes in math.h. [#932]
+  - Issue 929: Remove __ATTR_CONST__ from frexp* prototypes in math.h. [#932]
   - #890 #884: Fix / add entries for ATmega808/9, ATmega1608/9, ATmega3… [#927]
   - #921: Use all h files of $srcdir/include/avr in Makefile.am. enhancement [#925]
   - #892: configure.ac has outdated CHECK_AVR_DEVICE and AM_CONDITIONAL l… [#924]
@@ -248,7 +248,7 @@
 
 * Contributed Patches:
 
-  [no-id] Define weak symbols for known memory region sizes based on device 
+  [no-id] Define weak symbols for known memory region sizes based on device
   header definitions, starting with fuse region.
   [#8961] Update test script for new simulavr and library layout
   [#8964] Update tests isinf-01.c, signbit-01.c and modf-np.c

--- a/tests/simulate/avr/eeprom-1.c
+++ b/tests/simulate/avr/eeprom-1.c
@@ -98,7 +98,7 @@ int main ()
 
     /* Write only 1 word.	*/
     /* Avr-gcc 4.2.2 produces incorrect code: the comparison of address
-       with 5 and 6 values is omited. In result exit with error.
+       with 5 and 6 values is omitted. In result exit with error.
        Versions 3.3.6, 3.4.6, 4.0.4, 4.1.2, 4.2.3, 4.3.0(pre) give
        correct code and are simulated OK.	*/
     eeprom_write_word ((unsigned *)5, 0x1234);

--- a/tests/simulate/avr/sfr-1.c
+++ b/tests/simulate/avr/sfr-1.c
@@ -27,7 +27,7 @@
    POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Test of _SFR's macroses.  Default usage without any definition.
+/* Test of _SFR's macros.  Default usage without any definition.
    $Id$	*/
 
 #include <avr/io.h>

--- a/tests/simulate/avr/sfr-2.c
+++ b/tests/simulate/avr/sfr-2.c
@@ -27,7 +27,7 @@
    POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Test of _SFR's macroses.  Old style C program.
+/* Test of _SFR's macros.  Old style C program.
    $Id$	*/
 
 /* XXX: Seems, the _SFR_MEM_ADDR() is worse.  In case of _SFR_ASM_COMPAT

--- a/tests/simulate/avr/sfr-3.c
+++ b/tests/simulate/avr/sfr-3.c
@@ -27,7 +27,7 @@
    POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Test of _SFR's macroses.  Semi-old style C program, where the ports are
+/* Test of _SFR's macros.  Semi-old style C program, where the ports are
    the numbers, suitable to use with LDS/STS instruction.
    $Id$	*/
 

--- a/tests/simulate/avr/sfrasm-1.S
+++ b/tests/simulate/avr/sfrasm-1.S
@@ -27,7 +27,7 @@
    POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Test of _SFR's macroses.  Default usage.
+/* Test of _SFR's macros.  Default usage.
    $Id$	*/
 
 #include <avr/io.h>

--- a/tests/simulate/avr/sfrasm-2.S
+++ b/tests/simulate/avr/sfrasm-2.S
@@ -27,7 +27,7 @@
    POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Test of _SFR's macroses.  Old style ASM program, where the ports are
+/* Test of _SFR's macros.  Old style ASM program, where the ports are
    values, suitable to use with LDS/STS instruction.
    $Id$	*/
 

--- a/tests/simulate/avr/sfrasm-3.S
+++ b/tests/simulate/avr/sfrasm-3.S
@@ -27,7 +27,7 @@
    POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Test of _SFR's macroses.  Implicit setting of default behaviour.
+/* Test of _SFR's macros.  Implicit setting of default behaviour.
    $Id$	*/
 
 #define __SFR_OFFSET	0x20

--- a/tests/simulate/fplib/unll2flt-01.c
+++ b/tests/simulate/fplib/unll2flt-01.c
@@ -85,14 +85,14 @@ PROGMEM const struct {		/* Table of test cases:  x, (float)x	*/
     { 12345678000000000LL, { .fl = 1.2345678e+16 } },
     { 123456780000000000LL, { .fl = 1.2345678e+17 } },
     { 1234567800000000000LL, { .fl = 1.2345678e+18 } },
-    
+
     /* big values	*/
     { 0x7fffffffffffffffLL, { .fl = 0x1p+63 } },
     { 0x8000000000000000LL, { .fl = 0x1p+63 } },
     { 0x8000000000000001LL, { .fl = 0x1p+63 } },
     { 0xffffffffffffffffLL, { .fl = 0x1p+64 } },
-    
-    /* all possible shifts	*/    
+
+    /* all possible shifts	*/
     { 0x00000001, { .fl = 0x1p+00 } },
     { 0x00000002, { .fl = 0x1p+01 } },
     { 0x00000004, { .fl = 0x1p+02 } },
@@ -157,7 +157,7 @@ PROGMEM const struct {		/* Table of test cases:  x, (float)x	*/
     { 0x2000000000000000LL, { .fl = 0x1p+61 } },
     { 0x4000000000000000LL, { .fl = 0x1p+62 } },
     { 0x8000000000000000LL, { .fl = 0x1p+63 } },
-    
+
     /* bytes order	*/
     { 0x0000000000000102LL, { .fl = 0x102p+00 } },
     { 0x0000000000010203LL, { .fl = 0x10203p+00 } },
@@ -257,7 +257,7 @@ PROGMEM const struct {		/* Table of test cases:  x, (float)x	*/
     { 0x7ffffec0, { .fl = 0x0.fffffep+31 } },
     { 0x7fffff40, { .fl = 0x0.fffffep+31 } },
     { 0x7fffffc0, { .fl = 0x1.000000p+31 } },
-    
+
     /* LSB bits in rounding (shift to left)	*/
     { 0x01000000000000LL, { .fl = 0x0.800000p+49 } },
     { 0x01000001000000LL, { .fl = 0x0.800000p+49 } },
@@ -298,12 +298,12 @@ int main ()
     unsigned long long x;
     union lofl_u z;
     int i;
-    
+
     for (i = 0; i < (int) (sizeof(t) / sizeof(t[0])); i++) {
 	x = pgm_read_qword (& t[i].x);
 	z.lo = pgm_read_dword (& t[i].z);
 #ifdef __AVR__
-	/* Force library's convertion function usage. This is needed for
+	/* Force library's conversion function usage. This is needed for
 	   GCC before 4.2	*/
 	extern float __floatundisf (unsigned long long);
 	v.fl = __floatundisf (x);

--- a/tests/simulate/math/cbrt-01.c
+++ b/tests/simulate/math/cbrt-01.c
@@ -50,7 +50,7 @@ union float_u {
 };
 
 /* Result is placed into SRAM variable, allocated at the start of
-   memory. This is convinient to debug: read a core dump.	*/
+   memory. This is convenient to debug: read a core dump.	*/
 volatile union float_u v = {.u32 = 1};
 
 PROGMEM const struct {
@@ -77,7 +77,7 @@ PROGMEM const struct {
     { { 729 },	{ 9 } },
     { { 1000 },	{ 10 } },
     { {-1000 },	{-10 } },
-    
+
     { { 0.125 }, { 0.5 } },
     { { 0.015625 }, { 0.25 } },
     { {-0.001953125 }, {-0.125 } },
@@ -87,7 +87,7 @@ int main ()
 {
     int i;
     union float_u tx, tz;
-    
+
     for (i = 0;  (size_t)i < sizeof(t) / sizeof(t[0]); i++) {
 	tx.u32 = pgm_read_dword (& t[i].x);
 	tz.u32 = pgm_read_dword (& t[i].z);
@@ -98,6 +98,6 @@ int main ()
 	    EXIT (i + 1);
 	}
     }
-    
+
     return 0;
 }

--- a/tests/simulate/math/cbrt-02.c
+++ b/tests/simulate/math/cbrt-02.c
@@ -52,7 +52,7 @@ union float_u {
 };
 
 /* Result is placed into SRAM variable, allocated at the start of
-   memory. This is convinient to debug: read a core dump.	*/
+   memory. This is convenient to debug: read a core dump.	*/
 volatile union float_u v = {.u32 = 1};
 
 PROGMEM const struct {
@@ -344,7 +344,7 @@ int main ()
 {
     int i;
     union float_u tx, tz;
-    
+
     for (i = 0;  (size_t)i < sizeof(t) / sizeof(t[0]); i++) {
 	tx.u32 = pgm_read_dword (& t[i].x);
 	tz.u32 = pgm_read_dword (& t[i].z);
@@ -355,6 +355,6 @@ int main ()
 	    EXIT (i + 1);
 	}
     }
-    
+
     return 0;
 }

--- a/tests/simulate/math/cbrt-03.c
+++ b/tests/simulate/math/cbrt-03.c
@@ -52,7 +52,7 @@ union float_u {
 };
 
 /* Result is placed into SRAM variable, allocated at the start of
-   memory. This is convinient to debug: read a core dump.	*/
+   memory. This is convenient to debug: read a core dump.	*/
 volatile union float_u v = {.u32 = 1};
 
 PROGMEM const struct {
@@ -344,7 +344,7 @@ int main ()
 {
     int i;
     union float_u tx, tz;
-    
+
     for (i = 0;  (size_t)i < sizeof(t) / sizeof(t[0]); i++) {
 	tx.u32 = pgm_read_dword (& t[i].x);
 	tz.u32 = pgm_read_dword (& t[i].z);
@@ -355,6 +355,6 @@ int main ()
 	    EXIT (i + 1);
 	}
     }
-    
+
     return 0;
 }

--- a/tests/simulate/math/cbrt-500.c
+++ b/tests/simulate/math/cbrt-500.c
@@ -52,7 +52,7 @@ union float_u {
 };
 
 /* Result is placed into SRAM variable, allocated at the start of
-   memory. This is convinient to debug: read a core dump.	*/
+   memory. This is convenient to debug: read a core dump.	*/
 volatile union float_u v = {.u32 = 1};
 
 PROGMEM const struct {
@@ -568,7 +568,7 @@ int main ()
 {
     int i;
     union float_u tx, tz;
-    
+
     for (i = 0;  (size_t)i < sizeof(t) / sizeof(t[0]); i++) {
 	tx.u32 = pgm_read_dword (& t[i].x);
 	tz.u32 = pgm_read_dword (& t[i].z);
@@ -579,6 +579,6 @@ int main ()
 	    EXIT (i + 1);
 	}
     }
-    
+
     return 0;
 }

--- a/tests/simulate/math/cos-02.c
+++ b/tests/simulate/math/cos-02.c
@@ -50,7 +50,7 @@ union float_u {
 };
 
 /* Result is placed into SRAM variable, allocated at the start of
-   memory. This is convinient to debug: read a core dump.	*/
+   memory. This is convenient to debug: read a core dump.	*/
 volatile float vz = 1;
 volatile unsigned long ve = 1;
 
@@ -72,7 +72,7 @@ int main ()
     union float_u tx, tz;	/* from table		*/
     union float_u r;		/* calculation result	*/
     int i;
-    
+
     for (i = 0; i < (int) (sizeof(t) / sizeof(t[0])); i++) {
 	unsigned long delta;
 	tx.u32 = pgm_read_dword (& t[i].x);

--- a/tests/simulate/math/isinf-01.c
+++ b/tests/simulate/math/isinf-01.c
@@ -57,7 +57,7 @@ union lofl_u {
 };
 
 /* Result is placed into SRAM variable, allocated at the start of
-   memory. This is convinient to debug: read a core dump.	*/
+   memory. This is convenient to debug: read a core dump.	*/
 volatile int v = 1;
 
 PROGMEM const struct {		/* Table of test cases.	*/
@@ -68,7 +68,7 @@ PROGMEM const struct {		/* Table of test cases.	*/
     /* Zero	*/
     { { .fl= +0.0 },	0 },
     { { .fl= -0.0 },	0 },
-    
+
     /* A few of normal values	*/
     { { 0x00800000 },	0 },
     { { 0x00800001 },	0 },
@@ -80,7 +80,7 @@ PROGMEM const struct {		/* Table of test cases.	*/
     { { 0x80ffffff },	0 },
     { { 0xdf800000 },	0 },
     { { 0xff7fffff },	0 },
-    
+
     /* Subnormal	*/
     { { 0x00000001 }, 0 },
     { { 0x00000100 }, 0 },
@@ -93,7 +93,7 @@ PROGMEM const struct {		/* Table of test cases.	*/
 
     /* Inf	*/
     { { 0x7f800000 },	1 },
-    { { 0xff800000 },  -1 },    
+    { { 0xff800000 },  -1 },
 
     /* NaN	*/
     { { 0x7f800001 },	0 },
@@ -110,7 +110,7 @@ int main ()
     int z;
     int i;
 
-    /* Default implementation.	*/    
+    /* Default implementation.	*/
     for (i = 0; i < (int) (sizeof(t) / sizeof(t[0])); i++) {
 	x.lo = pgm_read_dword (& t[i].x);
 	z = pgm_read_word (& t[i].z);

--- a/tests/simulate/math/lrint-01.c
+++ b/tests/simulate/math/lrint-01.c
@@ -57,7 +57,7 @@ union lofl_u {
 };
 
 /* Result is placed into SRAM variable, allocated at the start of
-   memory. This is convinient to debug: read a core dump.	*/
+   memory. This is convenient to debug: read a core dump.	*/
 volatile long v = 1;
 
 PROGMEM const struct {		/* Table of test cases.	*/
@@ -68,7 +68,7 @@ PROGMEM const struct {		/* Table of test cases.	*/
     /* Zero	*/
     { { .fl= +0.0 },	0 },
     { { .fl= -0.0 },	0 },
-    
+
     /* A few of normal values	*/
     { { .fl= 0.1 },		0 },
     { { .fl= 0.5 },		0 },
@@ -98,7 +98,7 @@ PROGMEM const struct {		/* Table of test cases.	*/
     { { 0x80000100 }, 0 },
     { { 0x80010000 }, 0 },
     { { 0x807fffff }, 0 },
-    
+
     /* Margin values (positive).	*/
     { { 0x00800000 }, 0 },		/* the smallest nonzero normal	*/
 
@@ -224,7 +224,7 @@ int main ()
     long z;
     int i;
 
-    /* Table.	*/    
+    /* Table.	*/
     for (i = 0; i < (int) (sizeof(t) / sizeof(t[0])); i++) {
 	x.lo = pgm_read_dword (& t[i].x);
 	z = pgm_read_dword (& t[i].z);
@@ -296,7 +296,7 @@ int main ()
 	/* Change sign again and increment exponent.	*/
 	x.lo += 0x80800000;
     }
-    
+
     /* Rounding to up. Check a few values between 0.5 to 1.0 (as lrint(0.5)
        is 0, but lrint(0.5+delta) is 1).	*/
     for (i = 0; i < 22; i++) {

--- a/tests/simulate/math/lround-01.c
+++ b/tests/simulate/math/lround-01.c
@@ -57,7 +57,7 @@ union lofl_u {
 };
 
 /* Result is placed into SRAM variable, allocated at the start of
-   memory. This is convinient to debug: read a core dump.	*/
+   memory. This is convenient to debug: read a core dump.	*/
 volatile long v = 1;
 
 PROGMEM const struct {		/* Table of test cases.	*/
@@ -68,7 +68,7 @@ PROGMEM const struct {		/* Table of test cases.	*/
     /* Zero	*/
     { { .fl= +0.0 },	0 },
     { { .fl= -0.0 },	0 },
-    
+
     /* A few of normal values	*/
     { { .fl= 0.1 },		0 },
     { { .fl= 0.5 },		1 },
@@ -96,7 +96,7 @@ PROGMEM const struct {		/* Table of test cases.	*/
     { { 0x80000100 }, 0 },
     { { 0x80010000 }, 0 },
     { { 0x807fffff }, 0 },
-    
+
     /* Margin values (positive).	*/
     { { 0x00800000 }, 0 },		/* the smallest nonzero normal	*/
 
@@ -209,7 +209,7 @@ int main ()
     long z;
     int i;
 
-    /* Table.	*/    
+    /* Table.	*/
     for (i = 0; i < (int) (sizeof(t) / sizeof(t[0])); i++) {
 	x.lo = pgm_read_dword (& t[i].x);
 	z = pgm_read_dword (& t[i].z);

--- a/tests/simulate/math/signbit-01.c
+++ b/tests/simulate/math/signbit-01.c
@@ -57,7 +57,7 @@ union lofl_u {
 };
 
 /* Result is placed into SRAM variable, allocated at the start of
-   memory. This is convinient to debug: read a core dump.	*/
+   memory. This is convenient to debug: read a core dump.	*/
 volatile int v = 1;
 
 PROGMEM const struct {		/* Table of test cases.	*/
@@ -68,7 +68,7 @@ PROGMEM const struct {		/* Table of test cases.	*/
     /* Zero	*/
     { { .fl= +0.0 },	0 },
     { { .fl= -0.0 },	1 },
-    
+
     /* A few of normal values	*/
     { { 0x00800000 },	0 },
     { { 0x00800001 },	0 },
@@ -80,7 +80,7 @@ PROGMEM const struct {		/* Table of test cases.	*/
     { { 0x80ffffff },	1 },
     { { 0xdf800000 },	1 },
     { { 0xff7fffff },	1 },
-    
+
     /* Subnormal	*/
     { { 0x00000001 }, 0 },
     { { 0x00000100 }, 0 },
@@ -93,7 +93,7 @@ PROGMEM const struct {		/* Table of test cases.	*/
 
     /* Inf	*/
     { { 0x7f800000 },	0 },
-    { { 0xff800000 },	1 },    
+    { { 0xff800000 },	1 },
 
     /* NaN	*/
     { { 0x7f800001 },	0 },
@@ -111,7 +111,7 @@ int main ()
     int i;
     int (* volatile vp)(double);
 
-    /* Default implementation.	*/    
+    /* Default implementation.	*/
     for (i = 0; i < (int) (sizeof(t) / sizeof(t[0])); i++) {
 	x.lo = pgm_read_dword (& t[i].x);
 	z = pgm_read_word (& t[i].z);

--- a/tests/simulate/other/progtype-1.c
+++ b/tests/simulate/other/progtype-1.c
@@ -102,7 +102,7 @@ int main ()	{ return 0; }
      && sizeof (prefix##_uint64) == 8 * (nelems))
 
 
-/* With 64-bit values onle the little 4 bytes are checked.	*/
+/* With 64-bit values only the little 4 bytes are checked.	*/
 #define CHKVAL_SET(prefix, ch, uch, i8, u8, i16, u16, i32, u32, i64, u64) \
     (pgm_read_byte (& prefix##_char) == (ch)		\
      && pgm_read_byte (& prefix##_uchar) == (uch)	\

--- a/tests/simulate/regression/20081221-ffs.c
+++ b/tests/simulate/regression/20081221-ffs.c
@@ -28,9 +28,9 @@
  */
 
 /* The _FFS() macro is wrong in case of CPP conditional usage.
-   Seems, it is a bug in CPP parser in case of few '?:' expersions.
+   Seems, it is a bug in CPP parser in case of few '?:' expressions.
    The CC parser is correct.
-   
+
    $Id$
  */
 

--- a/tests/simulate/regression/bug-11820.c
+++ b/tests/simulate/regression/bug-11820.c
@@ -35,7 +35,7 @@
 
 int main ()
 {
-#ifdef	__AVR__		/* dtostre() is not a standart C function.	*/
+#ifdef	__AVR__		/* dtostre() is not a standard C function.	*/
     char s[20];
     dtostre (1e-15, s, 3, 0);
     if (strcmp (s, "1.000e-15")) exit (__LINE__);

--- a/tests/simulate/regression/bug-19134.c
+++ b/tests/simulate/regression/bug-19134.c
@@ -27,7 +27,7 @@
    POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* bug #19134: strcasecmp(): result sign is not changed by swaping args.
+/* bug #19134: strcasecmp(): result sign is not changed by swapping args.
    $Id$	*/
 
 #include <string.h>

--- a/tests/simulate/regression/bug-35093.c
+++ b/tests/simulate/regression/bug-35093.c
@@ -32,7 +32,7 @@
 
 #ifndef __AVR__
 
-/* Omit the test, as strlcat() is not a standart C function.	*/
+/* Omit the test, as strlcat() is not a standard C function.	*/
 int main ()	{ return 0; }
 
 #else

--- a/tests/simulate/stdlib/setjmp-1.c
+++ b/tests/simulate/stdlib/setjmp-1.c
@@ -78,7 +78,7 @@ int main ()
     }
 
     /* Repeat above with volatile function pointers: exclude
-       posible compiler optimization.	*/
+       possible compiler optimization.	*/
     v_setjmp = setjmp;
     v_longjmp = longjmp;
 
@@ -104,7 +104,7 @@ int main ()
 	default:
 	    exit (__LINE__);
     }
-    
+
     switch (v_setjmp (env)) {
 	case 0:
 	    v_longjmp (env, -1);

--- a/tests/simulate/stdlib/tolower-1.c
+++ b/tests/simulate/stdlib/tolower-1.c
@@ -53,7 +53,7 @@
 int main ()
 {
     int i, v;
-    
+
     for (i = -1; i < 256; i++) {
 	v = tolower (i);
 	if (i >= 'A' && i <= 'Z') {
@@ -68,10 +68,10 @@ int main ()
 	    }
 	}
     }
-    
 
-/* Skip the host, as according to C standart it is not safety to use an
-   argument beyound -1..255 value. AVR-LibC's ctype functions permit
+
+/* Skip the host, as according to C standard it is not safety to use an
+   argument beyond -1..255 value. AVR-LibC's ctype functions permit
    this.	*/
 #ifdef	__AVR__
     {

--- a/tests/simulate/stdlib/toupper-1.c
+++ b/tests/simulate/stdlib/toupper-1.c
@@ -53,7 +53,7 @@
 int main ()
 {
     int i, v;
-    
+
     for (i = -1; i < 256; i++) {
 	v = toupper (i);
 	if (i >= 'a' && i <= 'z') {
@@ -68,10 +68,10 @@ int main ()
 	    }
 	}
     }
-    
 
-/* Skip the host, as according to C standart it is not safety to use an
-   argument beyound -1..255 value. AVR-LibC's ctype functions permit
+
+/* Skip the host, as according to C standard it is not safety to use an
+   argument beyond -1..255 value. AVR-LibC's ctype functions permit
    this.	*/
 #ifdef	__AVR__
     {

--- a/tests/simulate/string/memchr.c
+++ b/tests/simulate/string/memchr.c
@@ -40,7 +40,7 @@ void Check (int line, const char *s, int c, size_t len, int expect)
 {
     char t[320];
     char *p;
-    
+
     if (len > sizeof(t))
 	exit (1);
     memcpy_P (t, s, len);
@@ -65,7 +65,7 @@ int main ()
     CHECK ("", 0, 0, -1);
     CHECK ("", 255, 0, -1);
     CHECK ("ABCDEF", 'a', 6, -1);
-    
+
     /* Found	*/
     CHECK ("\000", 0, 1, 0);
     CHECK ("\001", 1, 1, 0);
@@ -77,14 +77,14 @@ int main ()
     CHECK (".\000.", 0, 3, 1);
     CHECK ("\000a\000b", 'b', 4, 3);
 
-    /* First occurance	*/
+    /* First occurrence	*/
     CHECK ("abcdabcd", 'b', 8, 1);
     CHECK ("........", '.', 8, 0);
-    
+
     /* 'c' converted to a char	*/
     CHECK ("ABCDEF", 'A'+0x100, 6, 0);
     CHECK ("ABCDE\377", ~0, 6, 5);
-    
+
     /* Very long string	*/
     CHECK ("................................................................"
 	   "................................................................"

--- a/tests/simulate/string/memrchr.c
+++ b/tests/simulate/string/memrchr.c
@@ -56,7 +56,7 @@ void Check (int line, const char *s, int c, size_t len, int expect)
 {
     char t[320];
     char *p;
-    
+
     if (len > sizeof(t))
 	exit (1);
     memcpy_P (t, s, len);
@@ -89,7 +89,7 @@ int main ()
     CHECK ("", 0, 0, -1);
     CHECK ("", 255, 0, -1);
     CHECK ("ABCDEF", 'a', 6, -1);
-    
+
     /* Found	*/
     CHECK ("\000", 0, 1, 0);
     CHECK ("\001", 1, 1, 0);
@@ -101,14 +101,14 @@ int main ()
     CHECK (".\000.", 0, 3, 1);
     CHECK ("\000a\000b", 'b', 4, 3);
 
-    /* Last occurance	*/
+    /* Last occurrence	*/
     CHECK ("abcdabcd", 'b', 8, 5);
     CHECK ("........", '.', 8, 7);
-    
+
     /* 'c' converted to a char	*/
     CHECK ("ABCDEF", 'A'+0x100, 6, 0);
     CHECK ("ABCDE\377", ~0, 6, 5);
-    
+
     /* Very long string	*/
     CHECK ("................................................................"
 	   "................................................................"

--- a/tests/simulate/string/strchr.c
+++ b/tests/simulate/string/strchr.c
@@ -60,7 +60,7 @@ int main ()
     CHECK ("", 1, -1);
     CHECK ("", 255, -1);
     CHECK ("ABCDEF", 'a', -1);
-    
+
     /* Found	*/
     CHECK ("\001", 1, 0);
     CHECK ("\377", 255, 0);
@@ -70,13 +70,13 @@ int main ()
     CHECK ("12345", 0, 5);
     CHECK ("", 0, 0);
 
-    /* First occurance	*/
+    /* First occurrence	*/
     CHECK ("abcdabcd", 'b', 1);
-    
+
     /* 'c' converted to a char	*/
     CHECK ("ABCDEF", 'A'+0x100, 0);
     CHECK ("ABCDE\377", ~0, 5);
-    
+
     /* Very long string	*/
     CHECK ("................................................................"
 	   "................................................................"

--- a/tests/simulate/string/strchrnul.c
+++ b/tests/simulate/string/strchrnul.c
@@ -55,12 +55,12 @@
 void Check (int line, const char *s, int c, int expect)
 {
     char t[300], *p;
-    
+
     if (strlen_P(s) > sizeof(t) - 1)
 	exit (1);
     strcpy_P (t, s);
     p = strchrnul (t, c);
-    
+
     if (p != t + expect) {
 	PRINTFLN (line, "expect: %d, result: %d", expect, p - t);
 	EXIT (line);
@@ -81,7 +81,7 @@ int main ()
     CHECK ("", 1, 0);
     CHECK ("", 255, 0);
     CHECK ("ABCDEF", 'a', 6);
-    
+
     /* Found	*/
     CHECK ("\001", 1, 0);
     CHECK ("\377", 255, 0);
@@ -91,13 +91,13 @@ int main ()
     CHECK ("12345", 0, 5);
     CHECK ("", 0, 0);
 
-    /* First occurance	*/
+    /* First occurrence	*/
     CHECK ("abcdabcd", 'b', 1);
-    
+
     /* 'c' converted to a char	*/
     CHECK ("ABCDEF", 'A'+0x100, 0);
     CHECK ("ABCDE\377", ~0, 5);
-    
+
     /* Very long string	*/
     CHECK ("................................................................"
 	   "................................................................"

--- a/tests/simulate/string/strlwr.c
+++ b/tests/simulate/string/strlwr.c
@@ -37,7 +37,7 @@
 #include <string.h>
 #include "progmem.h"
 
-#ifndef	__AVR__			/* strlwr() is't a standart function	*/
+#ifndef	__AVR__			/* strlwr() is't a standard function	*/
 char * strlwr (char *s)
 {
     char *p = s;
@@ -84,7 +84,7 @@ int main ()
 {
     /* Empty string.	*/
     CHECK ("", "");
-    
+
     CHECK ("A", "a");
     CHECK ("Z", "z");
     CHECK ("@[", "@[");		/* '@'=='A'-1, '['=='Z'+1	*/
@@ -92,7 +92,7 @@ int main ()
 
     CHECK ("QWERTYUIOPASDFGHJKLZXCVBNM", "qwertyuiopasdfghjklzxcvbnm");
     CHECK ("FoO", "foo");
-    
+
     /* non-ASCII	*/
     CHECK ("\001A\177\200\201B\377", "\001a\177\200\201b\377");
 

--- a/tests/simulate/string/strrchr.c
+++ b/tests/simulate/string/strrchr.c
@@ -62,7 +62,7 @@ int main ()
     CHECK ("", 1, -1);
     CHECK ("", 255, -1);
     CHECK ("ABCDEF", 'a', -1);
-    
+
     /* Found	*/
     CHECK ("\001", 1, 0);
     CHECK ("\377", 255, 0);
@@ -72,16 +72,16 @@ int main ()
     CHECK ("12345", 0, 5);
     CHECK ("", 0, 0);
 
-    /* Last occurance	*/
+    /* Last occurrence	*/
     CHECK ("00", '0', 1);
     CHECK ("abcdabcd", 'b', 5);
     CHECK ("***********", '*', 10);
-    
+
     /* 'c' converted to a char	*/
     CHECK ("ABCDEF", 'A'+0x100, 0);
     CHECK ("ABCDE\377", ~0, 5);
     CHECK ("+", ~0xff, 1);
-    
+
     /* Very long string	*/
     CHECK ("................................................................"
 	   "................................................................"

--- a/tests/simulate/string/strrev.c
+++ b/tests/simulate/string/strrev.c
@@ -36,11 +36,11 @@
 #include <string.h>
 #include "progmem.h"
 
-#ifndef	__AVR__		/* strrev() is't a standart function	*/
+#ifndef	__AVR__		/* strrev() is't a standard function	*/
 char * strrev (char *s)
 {
     char *p1, *p2;
-    
+
     for (p2 = s; *p2; ) p2++;
     p1 = s;
     while (p1 < p2) {
@@ -98,16 +98,16 @@ int main ()
 {
     /* Empty string.	*/
     CHECK ("", "");
-    
+
     /* 1 char long	*/
     CHECK ("a", "a");
     CHECK ("\001", "\001");
     CHECK ("\377", "\377");
-    
+
     /* 2 chars long	*/
     CHECK ("01", "10");
     CHECK ("**", "**");
-    
+
     /* 3 and more chars long	*/
     CHECK ("abc", "cba");
     CHECK ("qwer", "rewq");
@@ -144,6 +144,6 @@ int main ()
 	   "6..............................................................5"
 	   "4..............................................................3"
 	   "2..............................................................1");
-    
+
     return 0;
 }

--- a/tests/simulate/string/strstr.c
+++ b/tests/simulate/string/strstr.c
@@ -81,7 +81,7 @@ int main ()
     CHECK (".a", "a", 1);
     CHECK (".a.", "a", 1);
     CHECK ("ABCDEFGH", "H", 7);
-    
+
     /* 'needle' of 2 bytes long	*/
     CHECK ("", "12", -1);
     CHECK ("13", "12", -1);
@@ -90,21 +90,21 @@ int main ()
     CHECK ("123", "12", 0);
     CHECK ("012", "12", 1);
     CHECK ("01200", "12", 1);
-    
-    /* partially mathing	*/
+
+    /* partially matching	*/
     CHECK ("a_ab_abc_abcd_abcde", "abcdef", -1);
     CHECK ("a_ab_abc_abcd_abcde_abcdef", "abcdef", 20);
     CHECK ("aababcabcdabcde", "abcdef", -1);
     CHECK ("aababcabcdabcdeabcdef", "abcdef", 15);
-    
+
     /* repeated chars	*/
     CHECK ("abaabaaabaaaab", "aaaaab", -1);
     CHECK ("abaabaaabaaaabaaaaab", "aaaaab", 14);
-    
+
     /* A first match is returned.	*/
     CHECK ("_foo_foo", "foo", 1);
-    
-    /* Case is importent.	*/
+
+    /* Case is important.	*/
     CHECK ("A", "a", -1);
 
     return 0;

--- a/tests/simulate/string/strupr.c
+++ b/tests/simulate/string/strupr.c
@@ -37,7 +37,7 @@
 #include <string.h>
 #include "progmem.h"
 
-#ifndef	__AVR__			/* strupr() is't a standart function	*/
+#ifndef	__AVR__			/* strupr() is't a standard function	*/
 char * strupr (char *s)
 {
     char *p = s;
@@ -84,7 +84,7 @@ int main ()
 {
     /* Empty string.	*/
     CHECK ("", "");
-    
+
     CHECK ("a", "A");
     CHECK ("z", "Z");
     CHECK ("@[", "@[");		/* '@'=='A'-1, '['=='Z'+1	*/
@@ -92,7 +92,7 @@ int main ()
 
     CHECK ("qwertyuiopasdfghjklzxcvbnm", "QWERTYUIOPASDFGHJKLZXCVBNM");
     CHECK ("fOo", "FOO");
-    
+
     /* non-ASCII	*/
     CHECK ("\001a\177\200\201b\377", "\001A\177\200\201B\377");
 


### PR DESCRIPTION
I am re-iterating previously closed pull request #982. I reset my `main` branch to the upstream, and squashed all the changes into a single commit. Hopefully, it would be easier to review and won't raise any merge conflicts.