### PR TITLE
Add a link to the building instructions to the GitHub page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@ The library is distributed using a modified BSD-style
 ## AVR-LibC Source Code
 
 The official source code repository is located at
-https://github.com/avrdudes/avr-libc/
+https://github.com/avrdudes/avr-libc/.
 
-### Building AVR-LibC from the Source Code
+### Building and installing AVR-LibC from source
 
 AVR-LibC depends on [GNU Binutils](https://sourceware.org/binutils/) (>= 2.13)
 and [GCC](https://gcc.gnu.org/) (>= 3.3) that should be built for the AVR
-target (configure --target=avr). Detailed instructions how to build these from
+target (`configure --target=avr`). Detailed instructions how to build these from
 source can be found on
-[Building and Installing the GNU Tool Chain](http://https://avrdudes.github.io/avr-libc/avr-libc-user-manual/install_tools.html) documentation page.
+[Building and Installing the GNU Tool Chain](https://avrdudes.github.io/avr-libc/avr-libc-user-manual/install_tools.html).
 
 Note that to build AVR-LibC directly by cloning the GitHub repository, you will
 need to run the `bootstrap` script in the root directory first. AVR-LibC uses
-[autoconf]() so be sure to use resent versions of `autoconf` (>= 1.9)
-and `automake` (>= 2.59) in order to generate the `configure`
-script and `Makefiles`. This also requires Python being installed and available
-in the system path.
+[autoconf](https://www.gnu.org/software/autoconf/) so be sure to use resent
+versions of `autoconf` (>= 1.9) and `automake` (>= 2.59) to generate the
+`configure` script and the `Makefiles`. This also requires Python being
+installed and available in the system path.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ source can be found on
 
 Note that to build AVR-LibC directly by cloning the GitHub repository, you will
 need to run the `bootstrap` script in the root directory first. AVR-LibC uses
-[autoconf](https://www.gnu.org/software/autoconf/) so be sure to use resent
+[autoconf](https://www.gnu.org/software/autoconf/) so be sure to use recent
 versions of `autoconf` (>= 1.9) and `automake` (>= 2.59) to generate the
-`configure` script and the `Makefiles`. This also requires Python being
+`configure` script and the `Makefile`s. This also requires Python being
 installed and available in the system path.

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ https://github.com/avrdudes/avr-libc/.
 
 ### Building and installing AVR-LibC from source
 
-AVR-LibC depends on [GNU Binutils](https://sourceware.org/binutils/) (>= 2.13)
-and [GCC](https://gcc.gnu.org/) (>= 3.3) that should be built for the AVR
-target (`configure --target=avr`). Detailed instructions how to build these from
-source can be found on
+AVR-LibC depends on [GNU Binutils](https://sourceware.org/binutils/) and
+[GCC](https://gcc.gnu.org/) that should be built for the AVR target. We
+recommend to use the most recent versions of these tools. Detailed instructions
+on building these tools from source can be found in
 [Building and Installing the GNU Tool Chain](https://avrdudes.github.io/avr-libc/avr-libc-user-manual/install_tools.html).
 
 Note that to build AVR-LibC directly by cloning the GitHub repository, you will
 need to run the `bootstrap` script in the root directory first. AVR-LibC uses
 [autoconf](https://www.gnu.org/software/autoconf/) so be sure to use recent
-versions of `autoconf` (>= 1.9) and `automake` (>= 2.59) to generate the
-`configure` script and the `Makefile`s. This also requires Python being
-installed and available in the system path.
+versions of `autoconf` and `automake` to generate the `configure` script and
+the `Makefile`s. This also requires Python being installed and available in
+the system path.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,18 @@ The library is distributed using a modified BSD-style
 
 The official source code repository is located at
 https://github.com/avrdudes/avr-libc/
+
+### Building AVR-LibC from the Source Code
+
+AVR-LibC depends on [GNU Binutils](https://sourceware.org/binutils/) (>= 2.13)
+and [GCC](https://gcc.gnu.org/) (>= 3.3) that should be built for the AVR
+target (configure --target=avr). Detailed instructions how to build these from
+source can be found on
+[Building and Installing the GNU Tool Chain](http://https://avrdudes.github.io/avr-libc/avr-libc-user-manual/install_tools.html) documentation page.
+
+Note that to build AVR-LibC directly by cloning the GitHub repository, you will
+need to run the `bootstrap` script in the root directory first. AVR-LibC uses
+[autoconf]() so be sure to use resent versions of `autoconf` (>= 1.9)
+and `automake` (>= 2.59) in order to generate the `configure`
+script and `Makefiles`. This also requires Python being installed and available
+in the system path.

--- a/common/ctoasm.inc
+++ b/common/ctoasm.inc
@@ -70,13 +70,13 @@
 
 
 
-#define rTI0     r31  /* 1st temporary with immidiate */
-#define rTI1     r30  /* 2nd temporary with immidiate */
-#define rTI2     r27  /* 3rd temporary with immidiate */
-#define rTI3     r26  /* 4th temporary with immidiate */
+#define rTI0     r31  /* 1st temporary with immediate */
+#define rTI1     r30  /* 2nd temporary with immediate */
+#define rTI2     r27  /* 3rd temporary with immediate */
+#define rTI3     r26  /* 4th temporary with immediate */
 
-/* registers wich have to be saved */
-#define rSI0     r17   /* first saved (pushed) register with immidiate */
+/* registers which have to be saved */
+#define rSI0     r17   /* first saved (pushed) register with immediate */
 #define rSI1     r16   /* 2nd push register  */
 #define rSI2     r29   /* 3rd saved (pushed) register */
 #define rSI3     r28   /* 4th saved (pushed) register  */

--- a/doc/api/inline_asm.dox
+++ b/doc/api/inline_asm.dox
@@ -854,7 +854,7 @@ with <tt>\ref opt_fverbose_asm "-fverbose-asm"</tt> since GCC v8.
 
 \subsection inline_asm_swap_nibbles Swapping Nibbles
 
-The fist example uses the \c swap instruction to swap the nibbles of
+The first example uses the \c swap instruction to swap the nibbles of
 a byte.  Input and output of \c swap are located in the same general
 purpose register.
 This means the input operand, operand 1 below, must be located in the


### PR DESCRIPTION
The information on how to build and install AVR-LibC from the source is not easily visible from the main page of the repo. 

As a GitHub user, I would like to see a quick link to how to build AVR-LibC. However, this requires running `bootstrap`, which may not be an obvious step, and it might not be easy to figure it out from the documentation quickly. As as simple option, I would suggest to add a paragraph with a couple of  notes and a link to the building instructions  directly on the main page.