### PR TITLE
Unit test fails when compiled with GCC 14.2 due to compiler optimizations

### DIFF
--- a/tests/simulate/regression/bug-27242.c
+++ b/tests/simulate/regression/bug-27242.c
@@ -31,6 +31,7 @@
 
 /* $Id$ */
 
+#include <avr/cpufunc.h>
 #include <stdlib.h>
 
 #include "../../libc/stdlib/stdlib_private.h"
@@ -56,6 +57,7 @@ int main(void)
 	 * the new __brkval starts immediately after the last allocated
 	 * chunk.
 	 */
+	_MemoryBarrier();
 	p = p1 + 10;
 	if (__brkval != p)
 		return 3;
@@ -79,6 +81,7 @@ int main(void)
 	if (p != p1)
 		return 7;
 
+	_MemoryBarrier();
 	p = p1 + 5;
 	if (__brkval != p)
 		return 8;


### PR DESCRIPTION
The following test fails (at `return 8`) when compiled with `-On` optimization flags, where `n = 1, 2, 3, s`  (Binutils 2.43.1 and GCC 14.2.0).  The test passes with disabled optimizations, `-O0`.  Stepping in with GDB suggests that a couple or  code rearrangements happens with enabled optimizations. Inserting memory barriers at those places, solves the problem (in principle, just one barrier at line 84 is enough). Probably, the simplest solution for this test would be just to add those memory barriers.

GCC is  `Configured with: ../gcc-14.2.0/configure --prefix=/home/igor/local/avr --target=avr --enable-languages=c --with-gnu-as --with-gnu-ld --with-dwarf2`.