### PR TITLE
Fix issue with dereferencing a null pointer

### DIFF
--- a/tests/simulate/regression/bug-27242.c
+++ b/tests/simulate/regression/bug-27242.c
@@ -38,7 +38,7 @@
 /* malloc() and friends are attributed "malloc", which asserts that the
    value returned by such a function won't alias any other variable.
    For the tests below to work as expected, we have to "get rid" of that
-   attribute (or use some other means like inline asm ho hide the result).  */
+   attribute (or use some other means like inline asm to hide the result).  */
 void* my_realloc (void*, size_t) __asm("realloc");
 void* my_malloc (size_t) __asm("malloc");
 #define malloc(a) my_malloc (a)

--- a/tests/simulate/regression/bug-28135.c
+++ b/tests/simulate/regression/bug-28135.c
@@ -38,7 +38,7 @@
 /* malloc() and friends are attributed "malloc", which asserts that the
    value returned by such a function won't alias any other variable.
    For the tests below to work as expected, we have to "get rid" of that
-   attribute (or use some other means like inline asm ho hide the result).  */
+   attribute (or use some other means like inline asm to hide the result).  */
 void* my_realloc (void*, size_t) __asm("realloc");
 void* my_malloc (size_t) __asm("malloc");
 #define malloc(a) my_malloc (a)

--- a/tests/simulate/stdlib/malloc-7.c
+++ b/tests/simulate/stdlib/malloc-7.c
@@ -50,7 +50,7 @@ int main ()
 /* malloc() and friends are attributed "malloc", which asserts that the
    value returned by such a function won't alias any other variable.
    For the tests below to work as expected, we have to "get rid" of that
-   attribute (or use some other means like inline asm ho hide the result).  */
+   attribute (or use some other means like inline asm to hide the result).  */
 void* my_realloc (void*, size_t) __asm("realloc");
 void* my_malloc (size_t) __asm("malloc");
 void my_free (void*) __asm("free");

--- a/tests/simulate/stdlib/realloc-3.c
+++ b/tests/simulate/stdlib/realloc-3.c
@@ -303,7 +303,7 @@ main(void)
   if (stats[0] != stats[1])
     exit(1);
 #ifdef __AVR__
-  if (__flp->nx != NULL)
+  if (__flp && __flp->nx != NULL)
     exit(2);
 #endif
   return 0;

--- a/tests/simulate/stdlib/realloc-3.c
+++ b/tests/simulate/stdlib/realloc-3.c
@@ -43,7 +43,7 @@
 /* malloc() and friends are attributed "malloc", which asserts that the
    value returned by such a function won't alias any other variable.
    For the tests below to work as expected, we have to "get rid" of that
-   attribute (or use some other means like inline asm ho hide the result).  */
+   attribute (or use some other means like inline asm to hide the result).  */
 void* my_realloc (void*, size_t) __asm("realloc");
 void* my_malloc (size_t) __asm("malloc");
 void my_free (void*) __asm("free");


### PR DESCRIPTION
Issue #988: Simulate: stdlib/realloc-3.c atmega128 ... *** simulate failed: 2

Fails because of dereferencing NULL pointer in  `__flp->nx != NULL`. `__flp` is set to NULL in `free()` when free-list is eliminated (which is the expected behavior).
