### PR TITLE
Avoid walking freelist twice in free()

### DIFF
--- a/libc/stdlib/malloc.c
+++ b/libc/stdlib/malloc.c
@@ -190,7 +190,7 @@ void
 free(void *p)
 {
 	struct __freelist *fp1, *fp2, *fpnew;
-	char *cp1, *cp2, *cpnew;
+	char *cp1, *cpnew;
 
 	/* ISO C says free(NULL) must be a no-op */
 	if (p == 0)
@@ -215,14 +215,14 @@ free(void *p)
 	             fp1->nx != 0;
 	             fp2 = fp1, fp1 = fp1->nx)
 			/* advance to entry just before end of list */;
-		cp2 = (char *)&(fp1->nx);
-		if (cp2 + fp1->sz == __brkval) {
+		cp1 = (char *)&(fp1->nx);
+		if (cp1 + fp1->sz == __brkval) {
 			if (fp2 == NULL)
 				/* Freelist is empty now. */
 				__flp = NULL;
 			else
 				fp2->nx = NULL;
-			__brkval = cp2 - sizeof(size_t);
+			__brkval = cp1 - sizeof(size_t);
 		}
 		return;
 	}
@@ -263,8 +263,8 @@ free(void *p)
 	 * with the lower chunk if possible.
 	 */
 	fp2->nx = fpnew;
-	cp2 = (char *)&(fp2->nx);
-	if (cp2 + fp2->sz == cpnew) {
+	cp1 = (char *)&(fp2->nx);
+	if (cp1 + fp2->sz == cpnew) {
 		/* lower junk adjacent, merge */
 		fp2->sz += fpnew->sz + sizeof(size_t);
 		fp2->nx = fpnew->nx;


### PR DESCRIPTION
Freelist in `free()` is walked twice: first time to find the position of the new chunk, and the second time to see if there is a new top-most chunk that can be absorbed into `__brkval`.  The second walk through the freelist is redundant and introduce visible  overhead (benchmarking is below) when the size of the freelist grows large.

The `free()` algorithm can be modified to avoid traversing through the entire list two times. Most of the code is reused, but the logic is rearranged in the following way.
1. Check if  `__brkval` can be reduced to `fpnew`.
2. If (1), traverse the list to find the last chunk, and see if it can be merged with new `__brkval`. Merge and eliminate the freelist if necessary. Anyway, we are done. Return.
3. Else (not (1)). Transverse the list to find the position of the new chunk. Merge new chunk either at the start, or in the middle, or at the end of the freelist. The list cannot be entirely eliminated in this branch. Return.

In this formulation, the list is either traversed once in (2) or in (3), but not twice. This approach shows performance gains in tests such as `malloc-8.c` and `realloc-3.c` where there is a large number of pseudo-random allocations/deallocations. 

Benchmarking results using `simulavr` with `gcc-14.2.0` and `-Os` optimization flag  are as follows (modified algorithm vs original algorithm, in CPU cycles):

malloc-8.c N=500
2008375   <- modified
2256447   <- original

malloc-8.c N=1000
4660592 
5443178

malloc-8.c N=2000
8495885 
9677264

malloc-8.c N=5000 (RAND_START_VALUE=1000)
23163097
26296019

realloc-3.c N=2000
2339246
2371133

realloc-3.c N=4000
5441688
5587853

Short tests show little or zero performance gains:
malloc-1.c
2183
2309
malloc-2.c
329
329
malloc-3.c
422
422
malloc-4.c
323
323
malloc-5.c
936  <- 4 cycles regression
932
malloc-6.c
924  <- 4 cycles regression
920
malloc-7.c
1333
1414