### PR TITLE
avr/iom6490.h: Atualização de definição de bit

### DIFF
--- a/include/avr/iom6490.h
+++ b/include/avr/iom6490.h
@@ -966,7 +966,7 @@
 
 #define LCDDR17 _SFR_MEM8(0XFD)
 #define SEG316  0
-#define SEG217  1
+#define SEG317  1
 #define SEG318  2
 #define SEG319  3
 #define SEG320  4


### PR DESCRIPTION
Correção de digitação do bit 1 do registrador LCDDR17. O bit 1 deve ser chamado de "SEG317" e não "SEG217".

ATmega329/3290/649/6490 Datasheet:
  23.4.5 LCD Memory Mapping