### PR TITLE
malloc-3.c: hide malloc attribute to prevent aggressive optimization

### DIFF
--- a/tests/simulate/stdlib/malloc-3.c
+++ b/tests/simulate/stdlib/malloc-3.c
@@ -44,6 +44,10 @@ int main ()
 #include <stdint.h>
 #include <stdlib.h>
 
+/* Attribute "malloc" may spoil this test, hence hide malloc.  */
+void* hidden_malloc (size_t) __asm("malloc");
+#define malloc(x) hidden_malloc(x)
+
 struct __freelist {
         size_t sz;
         struct __freelist *nx;


### PR DESCRIPTION
I noticed that `malloc-3.c` started to fail when compiled with GCC v. 15.0.0 20241123. Disabling optimizations from  `-Os` to `-O0` makes this test pass. I also noticed that this test does not "hide" malloc, and this might be the issue of aggressive optimization by GCC. Hiding malloc attribute seems to solve the problem -- the test pass with `-Os` optimizations enabled.