### PR TITLE
delay.h: Don't use __builtin_avr_delay_cycles() w/ clang

### DIFF
--- a/include/util/delay.h.in
+++ b/include/util/delay.h.in
@@ -36,7 +36,7 @@
 #define _UTIL_DELAY_H_ 1
 
 #ifndef __DOXYGEN__
-#  ifndef __HAS_DELAY_CYCLES
+#  if !defined(__HAS_DELAY_CYCLES) && !defined(__clang__)
 #    define __HAS_DELAY_CYCLES @HAS_DELAY_CYCLES@
 #  endif
 
@@ -106,6 +106,10 @@
 
 #ifndef __OPTIMIZE__
 # warning "Compiler optimizations disabled; functions from <util/delay.h> won't work as designed"
+#endif
+
+#ifdef __clang__
+# warning "Compiling with Clang; functions from <util/delay.h> won't work as designed"
 #endif
 
 /**


### PR DESCRIPTION
Clang compiler (as of version 21.0.0) doesn't have `__builtin_avr_delay_cycles`, which is used when `__HAS_DELAY_CYCLES` is set. This commit disables `__HAS_DELAY_CYCLES` for clang compiler, which is equivalent to `!defined(__OPTIMIZE__)` or
`defined(__DELAY_BACKWARD_COMPATIBLE__)`.