### PR TITLE
stdint.h: Use unsigned literal suffix for UINT8_MAX

### DIFF
--- a/include/stdint.h
+++ b/include/stdint.h
@@ -339,7 +339,7 @@ typedef uint64_t uintmax_t;
 /** \ingroup avr_stdint
     largest value an uint8_t can hold. */
 
-#define UINT8_MAX (INT8_MAX * 2 + 1)
+#define UINT8_MAX (__CONCAT(INT8_MAX, U) * 2U + 1U)
 
 /** \ingroup avr_stdint
     largest positive value an int16_t can hold. */


### PR DESCRIPTION
Unsigned literal suffix is missing in the definition of `UINT8_MAX` when `__USING_MINT8` is not defined.  This triggers `-Woverflow` compiler warnings in expressions like `UINT8_MAX * UINT8_MAX` because they are treated as having `int` type.