### PR TITLE
NEWS.md, Device.am, mlib-gen.py, pgmspace.dox, tools-install.dox: Fix typos.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,7 +38,7 @@
   `strspn`, `strspn_P`, `strcspn`, `strcspn_P`, `strlcat_P`, `strsep`,
   `strsep_P`, `strpbrk_P`, `strtok_rP`, `ltoa`, `ultoa`.
 
-- Support has beed added for the ISO/IEC TR 18037 fixed-point arithmetic
+- Support has been added for the ISO/IEC TR 18037 fixed-point arithmetic
   functions `rdivi`, `urdivi`, `lrdivi`, `ulrdivi` (#999),
   `sqrthr`, `sqrtuhr` (#1024).
 

--- a/devtools/Device.am
+++ b/devtools/Device.am
@@ -31,7 +31,7 @@
 AVR_TARGET          = <<dev>>
 if HAS_DEV_LIB
 if HAS_GCC_5_1
-# avr-gcc 5.1.0 expects crt file as crt1.o and 
+# avr-gcc 5.1.0 expects crt file as crt1.o and
 # device library in dev directory
 AVR_TARGET_CRT      = crt1.o
 AVR_TARGET_CVT      = crt1-cvt.o

--- a/devtools/mlib-gen.py
+++ b/devtools/mlib-gen.py
@@ -220,7 +220,7 @@ class Makefile (object):
         path = "/".join(dirs) + "/Makefile"
         clazz.files += [ Makefile(path) ]
 
-        # Try to mkdir the directory in in which Makefile.am will live.
+        # Try to mkdir the directory in which Makefile.am will live.
         path = os.path.join(*dirs)
         try:
             os.mkdir (path)

--- a/doc/api/pgmspace.dox
+++ b/doc/api/pgmspace.dox
@@ -54,13 +54,13 @@ types. This keyword is followed by an attribute specification in double
 parentheses. In AVR GCC, there is a special attribute called
 <a href="https://gcc.gnu.org/onlinedocs/gcc/AVR-Variable-Attributes.html#index-progmem-variable-attribute_002c-AVR"
    ><tt>progmem</tt></a>.
-This attribute is use on data definitions, and tells the compiler to place
+This attribute is used on data definitions, and tells the compiler to place
 the data in the Program Memory (Flash).
 
 AVR-LibC provides a simple macro #PROGMEM that is defined as the attribute
 syntax of GCC with the \c __progmem__ attribute. The PROGMEM macro is
 defined in the \ref avr_pgmspace "<avr/pgmspace.h>" system header
-which also provides macros and inline functions to access auch data.
+which also provides macros and inline functions to access such data.
 
 An alternative approach is taken by named address-spaces like #__flash
 and #__flashx

--- a/doc/api/tools-install.dox
+++ b/doc/api/tools-install.dox
@@ -572,7 +572,7 @@ GCC top source.  GCC will configure and build these libs during
     - Version 9.00
     - <https://www.ghostscript.com>
     - Download and install.
-    - In the \\bin subdirectory of the installaion, copy gswin32c.exe to gs.exe.
+    - In the \\bin subdirectory of the installation, copy gswin32c.exe to gs.exe.
 
 - Set the \c TEMP and \c TMP environment variables to <b><tt>c:\\\\temp</tt></b>
   or to the
@@ -618,7 +618,7 @@ make all html install install-html 2>&1 | tee binutils-make.log
 
 
 - <b>GCC</b><br>
-    - Open source code pacakge and patch as necessary.
+    - Open source code package and patch as necessary.
     - Configure and build in a directory outside of the source code tree.
     - Set PATH, in order:
         - \<MikTex executables\>
@@ -725,7 +725,7 @@ make -k all install 2>&1 | tee $package-make.log
     - Delete backup copy of avrdude config file in install directory if exists.
 
 - <b>Insight/GDB</b><br>
-    - Open source code pacakge and patch as necessary.
+    - Open source code package and patch as necessary.
     - Configure and build in a directory outside of the source code tree.
     - Set PATH, in order:
         - \<MikTex executables\>


### PR DESCRIPTION
Fix an few typos and a whitespace error.