### PR TITLE
sqrtsi.S: Integer part of a square root of uint32_t.

### DIFF
--- a/libc/misc/Files.am
+++ b/libc/misc/Files.am
@@ -71,6 +71,7 @@ misc_a_asm_sources = \
 	mulsi10.S \
 	mul10.S \
 	sqrthi.S \
+	sqrtsi.S \
 	ultoa.S \
 	ultoa_ncheck.S \
 	utoa.S \

--- a/libc/misc/sqrtsi.S
+++ b/libc/misc/sqrtsi.S
@@ -1,0 +1,54 @@
+#include "asmdef.h"
+
+;;; Argument in R25:R22 compliant with avr-gcc ABI.
+#define arg_hh r25
+#define arg_hl r24
+#define arg_hi r23
+#define arg_lo r22
+;;; Developing square root in R21:R20.
+#define res_hi r21
+#define res_lo r20
+;;; Rotation mask in R19:R18.
+#define msk_hi r19
+#define msk_lo r18
+
+/* sqrt32_floor: https://www.mikrocontroller.net/articles/AVR_Arithmetik */
+
+;;; Integer part of the square root of a 32-bit unsigned integer.
+;;; return (uint16_t) sqrtsi (uint32_t R22);
+ENTRY   __sqrtsi
+	sub res_lo, res_lo    ; clear and set C=0
+	ldi res_hi, 0x40      ; developing square root
+	clr msk_lo
+	ldi msk_hi, 0xc0      ; set rotation mask
+.L_next_bit:                  ; precondition: C=0
+	brcs 1f               ; C --> Bit is always 1
+	cp  arg_hl, res_lo
+	cpc arg_hh, res_hi    ; does test value fit?
+	brcs 2f
+1:
+	sub arg_hl, res_lo
+	sbc arg_hh, res_hi    ; adjust argument for next bit
+	or  res_lo, msk_lo
+	or  res_hi, msk_hi    ; set bit 1
+2:
+	lsr msk_hi
+	ror msk_lo            ; shift right mask, C --> end loop
+	eor res_hi, msk_hi
+	eor res_lo, msk_lo    ; shift right only test bit in result
+	rol arg_lo
+	rol arg_hi
+	rol arg_hl
+	rol arg_hh            ; shift left remaining argument (C used at 1:)
+	sbrs arg_lo, 0        ; skip if 15 bits developed
+	rjmp .L_next_bit      ; develop 15 bits of the sqrt
+
+	brcs 3f               ; C --> Last bit always 1
+	lsl  arg_hi           ; need bit 7 in C for cpc
+	cpc res_lo, arg_hl
+	cpc res_hi, arg_hh    ; after this C is last bit
+3:
+	adc res_lo, msk_hi    ; round up if C (msk_hi = 0)
+	X_movw arg_hl, res_lo ; return in R25:R24 for avr-gcc ABI
+	ret
+ENDFUNC

--- a/tests/simulate/stdfix/sqrtsi-1.c
+++ b/tests/simulate/stdfix/sqrtsi-1.c
@@ -1,0 +1,34 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+extern uint16_t __sqrtsi(uint32_t);
+
+int main(void)
+{
+	uint16_t i;
+	uint16_t r;
+	uint32_t j;
+	uint32_t sqr;
+	if (UINT16_MAX != 65535U) exit(__LINE__);
+	if (UINT32_MAX != 4294967295UL) exit(__LINE__);
+	/* Test limits first. */
+	r = __sqrtsi(0UL);
+	if (r != 0U) exit(__LINE__);
+	r = __sqrtsi(1UL);
+	if (r != 1U) exit(__LINE__);
+	r = __sqrtsi(UINT32_MAX);
+	if (r != UINT16_MAX) exit(__LINE__);
+	/* Test all perfect squares. */
+	for (i = 1U; i < UINT16_MAX; i++){
+		sqr = (uint32_t)i * (uint32_t)i;
+		r = __sqrtsi(sqr);
+		if (r != i) exit(__LINE__);
+	}
+	/* Test rounding down for large values. */
+	sqr = (uint32_t)UINT16_MAX * (uint32_t)UINT16_MAX;
+	for (j = sqr; j < UINT32_MAX; j++) {
+		r = __sqrtsi(j);
+		if (r != UINT16_MAX) exit (__LINE__);
+	}
+	return 0;
+}


### PR DESCRIPTION
Integer part of a square root of uint32_t returned as uint16_t using the algorithm for `sqrt32_floor`: https://www.mikrocontroller.net/articles/AVR_Arithmetik without any significant modifications (even with mostly original comment). 

The same algorithm is used for both: devices with and without MUL. I was tying to come up with a different algorithm for devices that have MUL/FMUL, but a naive approach with taking square first:
```
        ; Take square of res_hi:res_lo.
        ; (a 2^n + b)^2 = a^2 2^{2n} + 2^{n+1} ab + b^2
        mul res_lo, res_lo
        X_movw prd_lo, tmp_lo
        mul res_hi, res_hi
        X_movw prd_hl, tmp_lo
        mul res_lo, res_hi
        add prd_hi, tmp_lo
        adc prd_hl, tmp_hi
        adc prd_hh, zero
        add prd_hi, tmp_lo
        adc prd_hl, tmp_hi
        adc prd_hh, zero
```
and then comparing it with original result working out bit by bit is inferior to `sqrt32_floor` in terms of both code size and speed (270 cycles vs 430 cycles approximately).