### PR TITLE
pgmspace: Redefine `__ATTR_PROGMEM__` for clang using `__address_space__(1)`

### DIFF
--- a/include/bits/attribs.h
+++ b/include/bits/attribs.h
@@ -20,7 +20,7 @@
 /* AVR specific */
 
 #ifdef __clang__
-#define __ATTR_PROGMEM__ __attribute__((__section__(".progmem1.data")))
+#define __ATTR_PROGMEM__ __attribute__((__address_space__(1)))
 #else
 #define __ATTR_PROGMEM__ __attribute__((__progmem__))
 #endif


### PR DESCRIPTION
The original section-based attribute implied use of the extended flash space and required ELPM for access, as per the original design in LLVM's AVR backend.

This commit fixes the issue by redefining `__ATTR_PROGMEM__` to use the `__address_space__(1)`.

Reported in https://github.com/llvm/llvm-project/issues/128536#issuecomment-2777975111