### PR TITLE
Add LED blink example in main.c 

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,0 +1,14 @@
+#define F_CPU 16000000UL  // Define CPU frequency for delay
+#include <avr/io.h>
+#include <util/delay.h>
+
+int main(void) {
+    // Set pin 13 (PB5) as output
+    DDRB |= (1 << PB5);
+
+    while (1) {
+        // Toggle pin 13
+        PORTB ^= (1 << PB5);
+        _delay_ms(500);  // Wait 500 milliseconds
+    }
+}


### PR DESCRIPTION
This pull request adds a simple LED blink example in main.c using pure C for AVR microcontrollers. The code configures pin PB5 (Arduino Uno's digital pin 13) as an output and toggles it every 500 milliseconds using _delay_ms() from <util/delay.h>. This example is useful for beginners learning low-level AVR programming without relying on the Arduino IDE or its libraries.

Key Features:

Uses direct register manipulation (DDRB, PORTB)

Demonstrates basic timing with _delay_ms()

Compatible with ATmega328P (Arduino Uno)

Let me know if any improvements are needed. Happy to update the code!