### PR TITLE
wdt: fix new-WDT SYNCBUSY wait (use bit position) and add pre-write wait

### DIFF
--- a/include/avr/wdt.h
+++ b/include/avr/wdt.h
@@ -141,20 +141,23 @@
         uint8_t __temp;                                                 \
         __asm__ __volatile__ (                                          \
             "wdr"                                   "\n\t"              \
+            "1:lds %[tmp], %[wdt_status_reg]"       "\n\t"              \
+            "sbrc %[tmp], %[wdt_syncbusy_bit]"      "\n\t"              \
+            "rjmp 1b"                               "\n\t"              \
             "out %i[ccp_reg], %[ioreg_cen_mask]"    "\n\t"              \
             "lds %[tmp], %[wdt_reg]"                "\n\t"              \
             "sbr %[tmp], %[wdt_enable_timeout]"     "\n\t"              \
             "sts %[wdt_reg], %[tmp]"                "\n\t"              \
-            "1:lds %[tmp], %[wdt_status_reg]"       "\n\t"              \
+            "2:lds %[tmp], %[wdt_status_reg]"       "\n\t"              \
             "sbrc %[tmp], %[wdt_syncbusy_bit]"      "\n\t"              \
-            "rjmp 1b"                                                   \
+            "rjmp 2b"                                                   \
             : [tmp]                 "=d" (__temp)                       \
             : [ccp_reg]             "n"  (& CCP),                       \
               [ioreg_cen_mask]      "r"  ((uint8_t)CCP_IOREG_gc),       \
               [wdt_reg]             "n"  (& WDT_CTRLA),                 \
               [wdt_enable_timeout]  "M"  (timeout),                     \
               [wdt_status_reg]      "n"  (& WDT_STATUS),                \
-              [wdt_syncbusy_bit]    "I"  (WDT_SYNCBUSY_bm)              \
+              [wdt_syncbusy_bit]    "I"  (WDT_SYNCBUSY_bp)              \
             : "memory");                                                \
     } while(0)
 
@@ -164,6 +167,9 @@ void wdt_disable (void)
     uint8_t __temp;
     __asm__ __volatile__ (
         "wdr"                                "\n\t"
+        "1:lds %[tmp], %[wdt_status_reg]"    "\n\t"
+        "sbrc %[tmp], %[wdt_syncbusy_bit]"   "\n\t"
+        "rjmp 1b"                            "\n\t"
         "out %i[ccp_reg], %[ioreg_cen_mask]" "\n\t"
         "lds %[tmp], %[wdt_reg]"             "\n\t"
         "cbr %[tmp], %[timeout_mask]"        "\n\t"
@@ -172,7 +178,9 @@ void wdt_disable (void)
         : [ccp_reg]        "n" (& CCP),
           [ioreg_cen_mask] "r" ((uint8_t)CCP_IOREG_gc),
           [wdt_reg]        "n" (& WDT_CTRLA),
-          [timeout_mask]   "n" (WDT_PERIOD_gm)
+          [timeout_mask]   "n" (WDT_PERIOD_gm),
+          [wdt_status_reg] "n" (& WDT_STATUS),
+          [wdt_syncbusy_bit] "I" (WDT_SYNCBUSY_bp)
         : "memory");
 }
 


### PR DESCRIPTION
 ### Summary
On AVRs with the new-style Watchdog Timer (`WDT.CTRLA`), the `SYNCBUSY` wait loop in `wdt_enable()` is:
```
sbrc <reg>, WDT_SYNCBUSY_bm
```
`SBRC` takes a bit **number**, but `WDT_SYNCBUSY_bm` is the bit **mask** (`0x01`).
`SYNCBUSY` is bit 0 of `WDT.STATUS`, so the loop tests **bit 1** - a reserved bit that always reads 0 - and therefore never blocks.
So `wdt_enable()`'s post-write `SYNCBUSY` wait is a no-op, and `wdt_disable()` has no wait at all.

The datasheet requires *"Writing to WDT.CTRLA while SYNCBUSY = 1 is not allowed"*,
so two `CTRLA` updates issued close together can silently lose the second write.

### When it bites
A `CTRLA` write needs ~2-3 WDT-clock cycles (~2-3 ms) to synchronize, and `SYNCBUSY` is set for that whole window.
The dropped write only happens when a **second** `CTRLA` write lands inside that window - i.e. back-to-back WDT reconfiguration.
For example:
 - `wdt_disable(); wdt_enable(X);` (or the reverse): the second call writes `CTRLA` while the first is still synchronizing, so it is silently discarded and the WDT keeps the first state.
 - `wdt_enable(A); wdt_enable(B);`: with the no-op post-wait, `B` can be dropped and the WDT stays at `A`.

 An isolated `CTRLA` write is unaffected, because only a *following* write during `SYNCBUSY` is lost - the write itself still lands.

 ### Why it went unnoticed
 The common usage patterns all avoid the window: a lone `wdt_enable()`, a lone `wdt_disable()`,
or disabling the watchdog once early after reset (by then any reset-time `SYNCBUSY` has long cleared).
In each case `SYNCBUSY` is already 0 when `CTRLA` is written, so the broken (no-op) wait is harmless and the write lands.
The defect surfaces only when software reconfigures the WDT twice in quick succession,
which is why both the missing pre-write wait and the wrong-bit post-write wait went undetected.

 ### Change
 On the `defined(WDT_CTRLA) && !defined(RAMPD)` branch: use the bit **position** `WDT_SYNCBUSY_bp` in the wait condition,
and add a pre-write `SYNCBUSY` wait to both `wdt_enable()` and `wdt_disable()`.

 ### Verification
 On an AVR64DU32 a `SYNCBUSY` collision was forced (a `CTRLA` write left mid-sync, then the function under test run immediately) and `WDT.
CTRLA` read back:
 - with the `_bm` wait (current code / a naive copy): the colliding write is **discarded** (`enable` leaves `CTRLA = 0x00`; `disable` leaves the old `PERIOD`).
 - with the `_bp` wait: the write **lands** (`enable` → the requested `PERIOD`; `disable` → `0x00`).
