### PR TITLE
wdt: fix new-style WDT enable/disable on AVR Dx/DU (SYNCBUSY bit + CCP window)

### DIFF
--- a/include/avr/wdt.h
+++ b/include/avr/wdt.h
@@ -141,20 +141,21 @@
         uint8_t __temp;                                                 \
         __asm__ __volatile__ (                                          \
             "wdr"                                   "\n\t"              \
-            "out %i[ccp_reg], %[ioreg_cen_mask]"    "\n\t"              \
-            "lds %[tmp], %[wdt_reg]"                "\n\t"              \
-            "sbr %[tmp], %[wdt_enable_timeout]"     "\n\t"              \
-            "sts %[wdt_reg], %[tmp]"                "\n\t"              \
             "1:lds %[tmp], %[wdt_status_reg]"       "\n\t"              \
             "sbrc %[tmp], %[wdt_syncbusy_bit]"      "\n\t"              \
-            "rjmp 1b"                                                   \
-            : [tmp]                 "=d" (__temp)                       \
+            "rjmp 1b"                               "\n\t"              \
+            "out %i[ccp_reg], %[ioreg_cen_mask]"    "\n\t"              \
+            "sts %[wdt_reg], %[wdt_enable_timeout]" "\n\t"              \
+            "2:lds %[tmp], %[wdt_status_reg]"       "\n\t"              \
+            "sbrc %[tmp], %[wdt_syncbusy_bit]"      "\n\t"              \
+            "rjmp 2b"                                                   \
+            : [tmp]                 "=&d" (__temp)                      \
             : [ccp_reg]             "n"  (& CCP),                       \
               [ioreg_cen_mask]      "r"  ((uint8_t)CCP_IOREG_gc),       \
               [wdt_reg]             "n"  (& WDT_CTRLA),                 \
-              [wdt_enable_timeout]  "M"  (timeout),                     \
+              [wdt_enable_timeout]  "r"  ((uint8_t)(timeout)),          \
               [wdt_status_reg]      "n"  (& WDT_STATUS),                \
-              [wdt_syncbusy_bit]    "I"  (WDT_SYNCBUSY_bm)              \
+              [wdt_syncbusy_bit]    "I"  (WDT_SYNCBUSY_bp)              \
             : "memory");                                                \
     } while(0)
 
@@ -164,15 +165,18 @@ void wdt_disable (void)
     uint8_t __temp;
     __asm__ __volatile__ (
         "wdr"                                "\n\t"
+        "1:lds %[tmp], %[wdt_status_reg]"    "\n\t"
+        "sbrc %[tmp], %[wdt_syncbusy_bit]"   "\n\t"
+        "rjmp 1b"                            "\n\t"
         "out %i[ccp_reg], %[ioreg_cen_mask]" "\n\t"
-        "lds %[tmp], %[wdt_reg]"             "\n\t"
-        "cbr %[tmp], %[timeout_mask]"        "\n\t"
-        "sts %[wdt_reg], %[tmp]"
-        : [tmp]            "=d" (__temp)
+        "sts %[wdt_reg], %[wdt_off]"         "\n\t"
+        : [tmp]            "=&d" (__temp)
         : [ccp_reg]        "n" (& CCP),
           [ioreg_cen_mask] "r" ((uint8_t)CCP_IOREG_gc),
           [wdt_reg]        "n" (& WDT_CTRLA),
-          [timeout_mask]   "n" (WDT_PERIOD_gm)
+          [wdt_off]        "r" ((uint8_t)WDT_PERIOD_OFF_gc),
+          [wdt_status_reg] "n" (& WDT_STATUS),
+          [wdt_syncbusy_bit] "I" (WDT_SYNCBUSY_bp)
         : "memory");
 }
 


### PR DESCRIPTION

## Summary

The new-style WDT code path (`#if defined(WDT_CTRLA) && !defined(RAMPD)`) had two independent defects
that together left `wdt_enable()` / `wdt_disable()` non-functional on AVR Dx / DU and other modern AVRs that use the new WDT peripheral.
Both are only observable on real silicon, which is why they went unnoticed.
This PR fixes both problems.

Addresses the `wdt_enable()` reliability part of #1065 (reported on an ATtiny1616).
These defects are in the shared modern-WDT branch and are **not** specific to any one family -
they affect every modern AVR that takes this code path (tinyAVR 0/1/2 such as the ATtiny1616, megaAVR 0-series, and AVR Dx/DU).
The separate time-out-mapping issue also noted in #1065 is handled by a different change (`WDTO_*` -> `WDT.CTRLA` PERIOD group codes).

## Background

On these parts `WDT.CTRLA` is CCP-protected (key `IOREG`) and is synchronized to the WDT clock domain.
Per the data sheet, writing `WDT.CTRLA` while `WDT.STATUS.SYNCBUSY = 1` is not permitted,
and a protected write that does not occur within the CCP unlock window is discarded (the register is left unchanged).

## Bug 1 - SYNCBUSY wait tested the wrong bit

The synchronization-busy spin used:

```asm
sbrc %[reg], %[wdt_syncbusy_bit]    ; with WDT_SYNCBUSY_bm
```

`SBRC` takes a bit *position*, but `WDT_SYNCBUSY_bm` is the *mask* (`0x01`).
The instruction therefore tested bit 1 (always `0`), so the wait was a no-op.
This PR uses `WDT_SYNCBUSY_bp`.

A **pre-write** SYNCBUSY wait is also added. The previous code waited only *after* writing `CTRLA`;
if a previous change was still synchronizing, the new write could be issued while `SYNCBUSY = 1`,
which the hardware does not allow.

## Bug 2 — the CCP-protected store fell outside the unlock window

`wdt_enable()` / `wdt_disable()` did a read-modify-write of `WDT.CTRLA` *inside* the CCP window:

```asm
out CCP, sig          ; opens the unlock window
lds tmp, WDT.CTRLA
sbr/cbr tmp, ...
sts WDT.CTRLA, tmp    ; protected store — 3rd instruction after the unlock
```

The `IOREG` unlock only covers a few CPU cycles after the key write. `LDS` is
multi-cycle on these cores, so by the time the `STS` executes the window has
already closed and the protected store is silently discarded. Net effect:
`wdt_enable()` never enabled the WDT, and `wdt_disable()` could not stop a running
WDT.

**Fix:** load the value into a register *before* the unlock and write `WDT.CTRLA`
directly, so the `STS` is the first instruction after the key write and always
lands inside the window:

```asm
out CCP, sig
sts WDT.CTRLA, value  ; first instruction after the unlock
```

The classic `<avr/wdt.h>` API has no window concept, so writing the period
directly (`WINDOW = 0`) is the correct behaviour for both `enable` and `disable`.
The temporary used by the SYNCBUSY wait is marked early-clobber (`=&d`) so the
compiler does not allocate it to the register that holds the value to be stored.

## Verification

Tested on an AVR64DU32 (Curiosity Nano). As no released Arduino core currently supports the AVR DU family,
testing was done with a work-in-progress fork of DxCore (a modern-AVR Arduino core) that we have extended with AVR DU support;
the fork is used only to build and flash the test sketch and does not affect the behaviour under test.
https://github.com/ws-asahi/DxCore

- **Before:** `WDT.CTRLA` stayed `0x00` after `wdt_enable()`; no reset ever occurred.
- **After:** `WDT.CTRLA` reads back the requested period; the WDT issues a reset at the configured time-out (`RSTCTRL.RSTFR.WDRF` is set on the following boot);
 and `wdt_disable()` reliably returns a running WDT to `0x00` (confirmed by surviving 3x the time-out with no `wdt_reset()`).

## Scope

Only the modern branch (`defined(WDT_CTRLA) && !defined(RAMPD)`) is changed. The
legacy xmega branch (`RAMPD` present) is left untouched.